### PR TITLE
Fix/return type static

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.0",
         "ext-json": "*",
         "ext-mbstring": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=7.3",
         "ext-json": "*",
         "ext-mbstring": "*"
     },

--- a/src/Blocks/Actions.php
+++ b/src/Blocks/Actions.php
@@ -25,7 +25,7 @@ class Actions extends BlockElement
         }
     }
 
-    public function add(Element $element): self
+    public function add(Element $element): static
     {
         if (!in_array($element->getType(), Type::ACTION_ELEMENTS)) {
             throw new Exception('Invalid actions element type: %s', [$element->getType()]);

--- a/src/Blocks/Actions.php
+++ b/src/Blocks/Actions.php
@@ -25,7 +25,10 @@ class Actions extends BlockElement
         }
     }
 
-    public function add(Element $element): static
+    /**
+    * @return static
+    */
+    public function add(Element $element)
     {
         if (!in_array($element->getType(), Type::ACTION_ELEMENTS)) {
             throw new Exception('Invalid actions element type: %s', [$element->getType()]);

--- a/src/Blocks/BlockElement.php
+++ b/src/Blocks/BlockElement.php
@@ -24,9 +24,8 @@ abstract class BlockElement extends Element
 
     /**
      * @param string $blockId
-     * @return static
      */
-    public function blockId(string $blockId): self
+    public function blockId(string $blockId): static
     {
         $this->blockId = $blockId;
 

--- a/src/Blocks/BlockElement.php
+++ b/src/Blocks/BlockElement.php
@@ -24,8 +24,9 @@ abstract class BlockElement extends Element
 
     /**
      * @param string $blockId
+     * @return static
      */
-    public function blockId(string $blockId): static
+    public function blockId(string $blockId)
     {
         $this->blockId = $blockId;
 

--- a/src/Blocks/Context.php
+++ b/src/Blocks/Context.php
@@ -30,7 +30,7 @@ class Context extends BlockElement
         }
     }
 
-    public function add(Element $element): self
+    public function add(Element $element): static
     {
         if (!in_array($element->getType(), Type::CONTEXT_ELEMENTS)) {
             throw new Exception('Invalid context element type: %s', [$element->getType()]);
@@ -45,17 +45,17 @@ class Context extends BlockElement
         return $this;
     }
 
-    public function plainText(string $text, ?bool $emoji = null): self
+    public function plainText(string $text, ?bool $emoji = null): static
     {
         return $this->add(new PlainText($text, $emoji));
     }
 
-    public function mrkdwnText(string $text, ?bool $verbatim = null): self
+    public function mrkdwnText(string $text, ?bool $verbatim = null): static
     {
         return $this->add(new MrkdwnText($text, $verbatim));
     }
 
-    public function image(string $url, string $altText): self
+    public function image(string $url, string $altText): static
     {
         return $this->add(new Image(null, $url, $altText));
     }

--- a/src/Blocks/Context.php
+++ b/src/Blocks/Context.php
@@ -30,7 +30,10 @@ class Context extends BlockElement
         }
     }
 
-    public function add(Element $element): static
+    /**
+    * @return static
+    */
+    public function add(Element $element)
     {
         if (!in_array($element->getType(), Type::CONTEXT_ELEMENTS)) {
             throw new Exception('Invalid context element type: %s', [$element->getType()]);
@@ -45,17 +48,26 @@ class Context extends BlockElement
         return $this;
     }
 
-    public function plainText(string $text, ?bool $emoji = null): static
+    /**
+    * @return static
+    */
+    public function plainText(string $text, ?bool $emoji = null)
     {
         return $this->add(new PlainText($text, $emoji));
     }
 
-    public function mrkdwnText(string $text, ?bool $verbatim = null): static
+    /**
+    * @return static
+    */
+    public function mrkdwnText(string $text, ?bool $verbatim = null)
     {
         return $this->add(new MrkdwnText($text, $verbatim));
     }
 
-    public function image(string $url, string $altText): static
+    /**
+    * @return static
+    */
+    public function image(string $url, string $altText)
     {
         return $this->add(new Image(null, $url, $altText));
     }

--- a/src/Blocks/File.php
+++ b/src/Blocks/File.php
@@ -33,14 +33,20 @@ class File extends BlockElement
         }
     }
 
-    public function externalId(string $externalId): static
+    /**
+    * @return static
+    */
+    public function externalId(string $externalId)
     {
         $this->externalId = $externalId;
 
         return $this;
     }
 
-    public function source(string $source): static
+    /**
+    * @return static
+    */
+    public function source(string $source)
     {
         $this->source = $source;
 

--- a/src/Blocks/File.php
+++ b/src/Blocks/File.php
@@ -33,14 +33,14 @@ class File extends BlockElement
         }
     }
 
-    public function externalId(string $externalId): self
+    public function externalId(string $externalId): static
     {
         $this->externalId = $externalId;
 
         return $this;
     }
 
-    public function source(string $source): self
+    public function source(string $source): static
     {
         $this->source = $source;
 

--- a/src/Blocks/Header.php
+++ b/src/Blocks/Header.php
@@ -26,7 +26,7 @@ class Header extends BlockElement
         }
     }
 
-    public function setText(PlainText $text): self
+    public function setText(PlainText $text): static
     {
         $this->text = $text->setParent($this);
 
@@ -36,9 +36,8 @@ class Header extends BlockElement
     /**
      * @param string $text
      * @param bool|null $emoji
-     * @return self
      */
-    public function text(string $text, ?bool $emoji = null): self
+    public function text(string $text, ?bool $emoji = null): static
     {
         return $this->setText(new PlainText($text, $emoji));
     }

--- a/src/Blocks/Header.php
+++ b/src/Blocks/Header.php
@@ -26,7 +26,10 @@ class Header extends BlockElement
         }
     }
 
-    public function setText(PlainText $text): static
+    /**
+    * @return static
+    */
+    public function setText(PlainText $text)
     {
         $this->text = $text->setParent($this);
 
@@ -36,8 +39,9 @@ class Header extends BlockElement
     /**
      * @param string $text
      * @param bool|null $emoji
+     * @return static
      */
-    public function text(string $text, ?bool $emoji = null): static
+    public function text(string $text, ?bool $emoji = null)
     {
         return $this->setText(new PlainText($text, $emoji));
     }

--- a/src/Blocks/Image.php
+++ b/src/Blocks/Image.php
@@ -36,26 +36,26 @@ class Image extends BlockElement
         }
     }
 
-    public function setTitle(PlainText $title): self
+    public function setTitle(PlainText $title): static
     {
         $this->title = $title->setParent($this);
 
         return $this;
     }
 
-    public function title(string $text): self
+    public function title(string $text): static
     {
         return $this->setTitle(new PlainText($text));
     }
 
-    public function url(string $url): self
+    public function url(string $url): static
     {
         $this->url = $url;
 
         return $this;
     }
 
-    public function altText(string $alt): self
+    public function altText(string $alt): static
     {
         $this->altText = $alt;
 

--- a/src/Blocks/Image.php
+++ b/src/Blocks/Image.php
@@ -36,26 +36,38 @@ class Image extends BlockElement
         }
     }
 
-    public function setTitle(PlainText $title): static
+    /**
+    * @return static
+    */
+    public function setTitle(PlainText $title)
     {
         $this->title = $title->setParent($this);
 
         return $this;
     }
 
-    public function title(string $text): static
+    /**
+    * @return static
+    */
+    public function title(string $text)
     {
         return $this->setTitle(new PlainText($text));
     }
 
-    public function url(string $url): static
+    /**
+    * @return static
+    */
+    public function url(string $url)
     {
         $this->url = $url;
 
         return $this;
     }
 
-    public function altText(string $alt): static
+    /**
+    * @return static
+    */
+    public function altText(string $alt)
     {
         $this->altText = $alt;
 

--- a/src/Blocks/Input.php
+++ b/src/Blocks/Input.php
@@ -56,14 +56,14 @@ class Input extends BlockElement
         $this->dispatchAction = false;
     }
 
-    public function setLabel(Partials\PlainText $label): self
+    public function setLabel(Partials\PlainText $label): static
     {
         $this->label = $label->setParent($this);
 
         return $this;
     }
 
-    public function setElement(Element $element): self
+    public function setElement(Element $element): static
     {
         if (!empty($this->element)) {
             throw new Exception('Input element already set as type %s', [$this->element->getType()]);
@@ -78,31 +78,31 @@ class Input extends BlockElement
         return $this;
     }
 
-    public function setHint(Partials\PlainText $hint): self
+    public function setHint(Partials\PlainText $hint): static
     {
         $this->hint = $hint->setParent($this);
 
         return $this;
     }
 
-    public function label(string $text, ?bool $emoji = null): self
+    public function label(string $text, ?bool $emoji = null): static
     {
         return $this->setLabel(new Partials\PlainText($text, $emoji));
     }
 
-    public function hint(string $text, ?bool $emoji = null): self
+    public function hint(string $text, ?bool $emoji = null): static
     {
         return $this->setHint(new Partials\PlainText($text, $emoji));
     }
 
-    public function optional(bool $optional = true): self
+    public function optional(bool $optional = true): static
     {
         $this->optional = $optional;
 
         return $this;
     }
 
-    public function dispatchAction(bool $dispatchAction = true): self
+    public function dispatchAction(bool $dispatchAction = true): static
     {
         $this->dispatchAction = $dispatchAction;
 

--- a/src/Blocks/Input.php
+++ b/src/Blocks/Input.php
@@ -56,14 +56,20 @@ class Input extends BlockElement
         $this->dispatchAction = false;
     }
 
-    public function setLabel(Partials\PlainText $label): static
+    /**
+    * @return static
+    */
+    public function setLabel(Partials\PlainText $label)
     {
         $this->label = $label->setParent($this);
 
         return $this;
     }
 
-    public function setElement(Element $element): static
+    /**
+    * @return static
+    */
+    public function setElement(Element $element)
     {
         if (!empty($this->element)) {
             throw new Exception('Input element already set as type %s', [$this->element->getType()]);
@@ -78,31 +84,46 @@ class Input extends BlockElement
         return $this;
     }
 
-    public function setHint(Partials\PlainText $hint): static
+    /**
+    * @return static
+    */
+    public function setHint(Partials\PlainText $hint)
     {
         $this->hint = $hint->setParent($this);
 
         return $this;
     }
 
-    public function label(string $text, ?bool $emoji = null): static
+    /**
+    * @return static
+    */
+    public function label(string $text, ?bool $emoji = null)
     {
         return $this->setLabel(new Partials\PlainText($text, $emoji));
     }
 
-    public function hint(string $text, ?bool $emoji = null): static
+    /**
+    * @return static
+    */
+    public function hint(string $text, ?bool $emoji = null)
     {
         return $this->setHint(new Partials\PlainText($text, $emoji));
     }
 
-    public function optional(bool $optional = true): static
+    /**
+    * @return static
+    */
+    public function optional(bool $optional = true)
     {
         $this->optional = $optional;
 
         return $this;
     }
 
-    public function dispatchAction(bool $dispatchAction = true): static
+    /**
+    * @return static
+    */
+    public function dispatchAction(bool $dispatchAction = true)
     {
         $this->dispatchAction = $dispatchAction;
 

--- a/src/Blocks/Section.php
+++ b/src/Blocks/Section.php
@@ -40,8 +40,9 @@ class Section extends BlockElement
 
     /**
      * @param Partials\Text $text
+     * @return static
      */
-    public function setText(Partials\Text $text): static
+    public function setText(Partials\Text $text)
     {
         $this->text = $text->setParent($this);
 
@@ -50,8 +51,9 @@ class Section extends BlockElement
 
     /**
      * @param Partials\Fields $fields
+     * @return static
      */
-    public function setFields(Partials\Fields $fields): static
+    public function setFields(Partials\Fields $fields)
     {
         $this->fields = $fields->setParent($this);
 
@@ -60,8 +62,9 @@ class Section extends BlockElement
 
     /**
      * @param Element $accessory
+     * @return static
      */
-    public function setAccessory(Element $accessory): static
+    public function setAccessory(Element $accessory)
     {
         if (!empty($this->accessory)) {
             throw new Exception('Section accessory already set as type %s', [$this->accessory->getType()]);
@@ -79,8 +82,9 @@ class Section extends BlockElement
     /**
      * @param string $text
      * @param bool $emoji
+     * @return static
      */
-    public function plainText(string $text, ?bool $emoji = null): static
+    public function plainText(string $text, ?bool $emoji = null)
     {
         return $this->setText(new Partials\PlainText($text, $emoji));
     }
@@ -88,32 +92,36 @@ class Section extends BlockElement
     /**
      * @param string $text
      * @param bool|null $verbatim
+     * @return static
      */
-    public function mrkdwnText(string $text, ?bool $verbatim = null): static
+    public function mrkdwnText(string $text, ?bool $verbatim = null)
     {
         return $this->setText(new Partials\MrkdwnText($text, $verbatim));
     }
 
     /**
      * @param string $code
+     * @return static
      */
-    public function code(string $code): static
+    public function code(string $code)
     {
         return $this->mrkdwnText(Kit::formatter()->codeBlock($code), true);
     }
 
     /**
      * @param string[] $values
+     * @return static
      */
-    public function fieldList(array $values): static
+    public function fieldList(array $values)
     {
         return $this->setFields(new Partials\Fields($values));
     }
 
     /**
      * @param array $keyValuePairs
+     * @return static
      */
-    public function fieldMap(array $keyValuePairs): static
+    public function fieldMap(array $keyValuePairs)
     {
         $fields = new Partials\Fields();
         foreach ($keyValuePairs as $key => $value) {

--- a/src/Blocks/Section.php
+++ b/src/Blocks/Section.php
@@ -40,9 +40,8 @@ class Section extends BlockElement
 
     /**
      * @param Partials\Text $text
-     * @return self
      */
-    public function setText(Partials\Text $text): self
+    public function setText(Partials\Text $text): static
     {
         $this->text = $text->setParent($this);
 
@@ -51,9 +50,8 @@ class Section extends BlockElement
 
     /**
      * @param Partials\Fields $fields
-     * @return self
      */
-    public function setFields(Partials\Fields $fields): self
+    public function setFields(Partials\Fields $fields): static
     {
         $this->fields = $fields->setParent($this);
 
@@ -62,9 +60,8 @@ class Section extends BlockElement
 
     /**
      * @param Element $accessory
-     * @return self
      */
-    public function setAccessory(Element $accessory): self
+    public function setAccessory(Element $accessory): static
     {
         if (!empty($this->accessory)) {
             throw new Exception('Section accessory already set as type %s', [$this->accessory->getType()]);
@@ -82,9 +79,8 @@ class Section extends BlockElement
     /**
      * @param string $text
      * @param bool $emoji
-     * @return self
      */
-    public function plainText(string $text, ?bool $emoji = null): self
+    public function plainText(string $text, ?bool $emoji = null): static
     {
         return $this->setText(new Partials\PlainText($text, $emoji));
     }
@@ -92,36 +88,32 @@ class Section extends BlockElement
     /**
      * @param string $text
      * @param bool|null $verbatim
-     * @return self
      */
-    public function mrkdwnText(string $text, ?bool $verbatim = null): self
+    public function mrkdwnText(string $text, ?bool $verbatim = null): static
     {
         return $this->setText(new Partials\MrkdwnText($text, $verbatim));
     }
 
     /**
      * @param string $code
-     * @return self
      */
-    public function code(string $code): self
+    public function code(string $code): static
     {
         return $this->mrkdwnText(Kit::formatter()->codeBlock($code), true);
     }
 
     /**
      * @param string[] $values
-     * @return self
      */
-    public function fieldList(array $values): self
+    public function fieldList(array $values): static
     {
         return $this->setFields(new Partials\Fields($values));
     }
 
     /**
      * @param array $keyValuePairs
-     * @return self
      */
-    public function fieldMap(array $keyValuePairs): self
+    public function fieldMap(array $keyValuePairs): static
     {
         $fields = new Partials\Fields();
         foreach ($keyValuePairs as $key => $value) {

--- a/src/Blocks/Virtual/TwoColumnTable.php
+++ b/src/Blocks/Virtual/TwoColumnTable.php
@@ -53,9 +53,8 @@ class TwoColumnTable extends VirtualBlock
      * Sets a caption (text element) at the top of the table.
      *
      * @param string $caption
-     * @return self
      */
-    public function caption(string $caption): self
+    public function caption(string $caption): static
     {
         if (!$this->header) {
             $this->header = new Section();
@@ -74,9 +73,8 @@ class TwoColumnTable extends VirtualBlock
      *
      * @param string $left
      * @param string $right
-     * @return self
      */
-    public function cols(string $left, string $right): self
+    public function cols(string $left, string $right): static
     {
         if (!$this->header) {
             $this->header = new Section();
@@ -93,9 +91,8 @@ class TwoColumnTable extends VirtualBlock
      *
      * @param string $left
      * @param string $right
-     * @return TwoColumnTable
      */
-    public function row(string $left, string $right): self
+    public function row(string $left, string $right): static
     {
         $row = new Section();
         $row->fieldList([$left, $right]);
@@ -110,9 +107,8 @@ class TwoColumnTable extends VirtualBlock
      * Supports list-format (e.g., [[$left, $right], ...]) or map-format (e.g., [$left => $right, ...]) as input.
      *
      * @param array $rows
-     * @return TwoColumnTable
      */
-    public function rows(array $rows): self
+    public function rows(array $rows): static
     {
         if (isset($rows[0])) {
             foreach ($rows as [$left, $right]) {

--- a/src/Blocks/Virtual/TwoColumnTable.php
+++ b/src/Blocks/Virtual/TwoColumnTable.php
@@ -53,8 +53,9 @@ class TwoColumnTable extends VirtualBlock
      * Sets a caption (text element) at the top of the table.
      *
      * @param string $caption
+     * @return static
      */
-    public function caption(string $caption): static
+    public function caption(string $caption)
     {
         if (!$this->header) {
             $this->header = new Section();
@@ -73,8 +74,9 @@ class TwoColumnTable extends VirtualBlock
      *
      * @param string $left
      * @param string $right
+     * @return static
      */
-    public function cols(string $left, string $right): static
+    public function cols(string $left, string $right)
     {
         if (!$this->header) {
             $this->header = new Section();
@@ -91,8 +93,9 @@ class TwoColumnTable extends VirtualBlock
      *
      * @param string $left
      * @param string $right
+     * @return static
      */
-    public function row(string $left, string $right): static
+    public function row(string $left, string $right)
     {
         $row = new Section();
         $row->fieldList([$left, $right]);
@@ -107,8 +110,9 @@ class TwoColumnTable extends VirtualBlock
      * Supports list-format (e.g., [[$left, $right], ...]) or map-format (e.g., [$left => $right, ...]) as input.
      *
      * @param array $rows
+     * @return static
      */
-    public function rows(array $rows): static
+    public function rows(array $rows)
     {
         if (isset($rows[0])) {
             foreach ($rows as [$left, $right]) {

--- a/src/Blocks/Virtual/VirtualBlock.php
+++ b/src/Blocks/Virtual/VirtualBlock.php
@@ -25,8 +25,9 @@ abstract class VirtualBlock extends BlockElement implements IteratorAggregate
 
     /**
      * @param BlockElement $block
+     * @return static
      */
-    protected function appendBlock(BlockElement $block): static
+    protected function appendBlock(BlockElement $block)
     {
         if ($this->getParent() !== null) {
             $block->setParent($this->getParent());
@@ -37,7 +38,10 @@ abstract class VirtualBlock extends BlockElement implements IteratorAggregate
         return $this;
     }
 
-    protected function prependBlock(BlockElement $block): static
+    /**
+    * @return static
+    */
+    protected function prependBlock(BlockElement $block)
     {
         if ($this->getParent() !== null) {
             $block->setParent($this->getParent());

--- a/src/Blocks/Virtual/VirtualBlock.php
+++ b/src/Blocks/Virtual/VirtualBlock.php
@@ -25,9 +25,8 @@ abstract class VirtualBlock extends BlockElement implements IteratorAggregate
 
     /**
      * @param BlockElement $block
-     * @return static
      */
-    protected function appendBlock(BlockElement $block): self
+    protected function appendBlock(BlockElement $block): static
     {
         if ($this->getParent() !== null) {
             $block->setParent($this->getParent());
@@ -38,7 +37,7 @@ abstract class VirtualBlock extends BlockElement implements IteratorAggregate
         return $this;
     }
 
-    protected function prependBlock(BlockElement $block): self
+    protected function prependBlock(BlockElement $block): static
     {
         if ($this->getParent() !== null) {
             $block->setParent($this->getParent());

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,9 +15,9 @@ final class Config
     /** @var bool|null */
     private $defaultEmojiSetting = null;
 
-    public static function new(): self
+    public static function new(): static
     {
-        return new self();
+        return new static();
     }
 
     public function getDefaultVerbatimSetting(): ?bool
@@ -25,7 +25,7 @@ final class Config
         return $this->defaultVerbatimSetting;
     }
 
-    public function setDefaultVerbatimSetting(?bool $verbatim): self
+    public function setDefaultVerbatimSetting(?bool $verbatim): static
     {
         $this->defaultVerbatimSetting = $verbatim;
 
@@ -37,7 +37,7 @@ final class Config
         return $this->defaultEmojiSetting;
     }
 
-    public function setDefaultEmojiSetting(?bool $emoji): self
+    public function setDefaultEmojiSetting(?bool $emoji): static
     {
         $this->defaultEmojiSetting = $emoji;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,7 +15,10 @@ final class Config
     /** @var bool|null */
     private $defaultEmojiSetting = null;
 
-    public static function new(): static
+    /**
+     * @return static
+     */
+    public static function new()
     {
         return new static();
     }
@@ -25,7 +28,10 @@ final class Config
         return $this->defaultVerbatimSetting;
     }
 
-    public function setDefaultVerbatimSetting(?bool $verbatim): static
+    /**
+     * @return static
+     */
+    public function setDefaultVerbatimSetting(?bool $verbatim)
     {
         $this->defaultVerbatimSetting = $verbatim;
 
@@ -37,7 +43,10 @@ final class Config
         return $this->defaultEmojiSetting;
     }
 
-    public function setDefaultEmojiSetting(?bool $emoji): static
+    /**
+     * @return static
+     */
+    public function setDefaultEmojiSetting(?bool $emoji)
     {
         $this->defaultEmojiSetting = $emoji;
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -15,10 +15,7 @@ abstract class Element implements JsonSerializable
     /** @var array */
     protected $extra;
 
-    /**
-     * @return static
-     */
-    public static function new()
+    public static function new(): static
     {
         return new static();
     }
@@ -33,9 +30,8 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param Element $parent
-     * @return static
      */
-    final public function setParent(Element $parent): self
+    final public function setParent(Element $parent): static
     {
         $this->parent = $parent;
 
@@ -55,9 +51,8 @@ abstract class Element implements JsonSerializable
      *
      * @param string $key
      * @param mixed $value
-     * @return static
      */
-    final public function setExtra(string $key, $value): self
+    final public function setExtra(string $key, $value): static
     {
         $this->extra[$key] = $value;
 
@@ -74,9 +69,8 @@ abstract class Element implements JsonSerializable
      *         });
      *
      * @param callable $tap
-     * @return static
      */
-    final public function tap(callable $tap): self
+    final public function tap(callable $tap): static
     {
         $tap($this);
 
@@ -94,9 +88,8 @@ abstract class Element implements JsonSerializable
      *
      * @param bool $condition
      * @param callable $tap
-     * @return static
      */
-    final public function tapIf(bool $condition, callable $tap): self
+    final public function tapIf(bool $condition, callable $tap): static
     {
         if ($condition) {
             $tap($this);
@@ -147,9 +140,8 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param string $json
-     * @return static
      */
-    final public static function fromJson(string $json)
+    final public static function fromJson(string $json): static
     {
         try {
             $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
@@ -162,9 +154,8 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param array $data
-     * @return static
      */
-    final public static function fromArray(array $data)
+    final public static function fromArray(array $data): static
     {
         $data = new HydrationData($data);
 

--- a/src/Element.php
+++ b/src/Element.php
@@ -15,7 +15,10 @@ abstract class Element implements JsonSerializable
     /** @var array */
     protected $extra;
 
-    public static function new(): static
+    /**
+     * @return static
+     */
+    public static function new()
     {
         return new static();
     }
@@ -30,8 +33,9 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param Element $parent
+     * @return static
      */
-    final public function setParent(Element $parent): static
+    final public function setParent(Element $parent)
     {
         $this->parent = $parent;
 
@@ -51,8 +55,9 @@ abstract class Element implements JsonSerializable
      *
      * @param string $key
      * @param mixed $value
+     * @return static
      */
-    final public function setExtra(string $key, $value): static
+    final public function setExtra(string $key, $value)
     {
         $this->extra[$key] = $value;
 
@@ -69,8 +74,9 @@ abstract class Element implements JsonSerializable
      *         });
      *
      * @param callable $tap
+     * @return static
      */
-    final public function tap(callable $tap): static
+    final public function tap(callable $tap)
     {
         $tap($this);
 
@@ -88,8 +94,9 @@ abstract class Element implements JsonSerializable
      *
      * @param bool $condition
      * @param callable $tap
+     * @return static
      */
-    final public function tapIf(bool $condition, callable $tap): static
+    final public function tapIf(bool $condition, callable $tap)
     {
         if ($condition) {
             $tap($this);
@@ -140,8 +147,9 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param string $json
+     * @return static
      */
-    final public static function fromJson(string $json): static
+    final public static function fromJson(string $json)
     {
         try {
             $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
@@ -154,8 +162,9 @@ abstract class Element implements JsonSerializable
 
     /**
      * @param array $data
+     * @return static
      */
-    final public static function fromArray(array $data): static
+    final public static function fromArray(array $data)
     {
         $data = new HydrationData($data);
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -39,9 +39,9 @@ final class Formatter
     public const TIME = '{time}';
     public const TIME_SECS = '{time_secs}';
 
-    public static function new(): self
+    public static function new(): static
     {
-        return new self();
+        return new static();
     }
 
     /**

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -39,7 +39,10 @@ final class Formatter
     public const TIME = '{time}';
     public const TIME_SECS = '{time_secs}';
 
-    public static function new(): static
+    /**
+    * @return static
+    */
+    public static function new()
     {
         return new static();
     }

--- a/src/Inputs/Button.php
+++ b/src/Inputs/Button.php
@@ -28,40 +28,58 @@ class Button extends InputElement
     /** @var string|null */
     private $style;
 
-    public function setText(PlainText $text): static
+    /**
+    * @return static
+    */
+    public function setText(PlainText $text)
     {
         $this->text = $text->setParent($this);
 
         return $this;
     }
 
-    public function text(string $text): static
+    /**
+    * @return static
+    */
+    public function text(string $text)
     {
         return $this->setText(new PlainText($text));
     }
 
-    public function value(string $value): static
+    /**
+    * @return static
+    */
+    public function value(string $value)
     {
         $this->value = $value;
 
         return $this;
     }
 
-    public function url(string $url): static
+    /**
+    * @return static
+    */
+    public function url(string $url)
     {
         $this->url = $url;
 
         return $this;
     }
 
-    public function asPrimary(): static
+    /**
+    * @return static
+    */
+    public function asPrimary()
     {
         $this->style = self::STYLE_PRIMARY;
 
         return $this;
     }
 
-    public function asDangerous(): static
+    /**
+    * @return static
+    */
+    public function asDangerous()
     {
         $this->style = self::STYLE_DANGER;
 

--- a/src/Inputs/Button.php
+++ b/src/Inputs/Button.php
@@ -28,40 +28,40 @@ class Button extends InputElement
     /** @var string|null */
     private $style;
 
-    public function setText(PlainText $text): self
+    public function setText(PlainText $text): static
     {
         $this->text = $text->setParent($this);
 
         return $this;
     }
 
-    public function text(string $text): self
+    public function text(string $text): static
     {
         return $this->setText(new PlainText($text));
     }
 
-    public function value(string $value): self
+    public function value(string $value): static
     {
         $this->value = $value;
 
         return $this;
     }
 
-    public function url(string $url): self
+    public function url(string $url): static
     {
         $this->url = $url;
 
         return $this;
     }
 
-    public function asPrimary(): self
+    public function asPrimary(): static
     {
         $this->style = self::STYLE_PRIMARY;
 
         return $this;
     }
 
-    public function asDangerous(): self
+    public function asDangerous(): static
     {
         $this->style = self::STYLE_DANGER;
 

--- a/src/Inputs/DatePicker.php
+++ b/src/Inputs/DatePicker.php
@@ -20,7 +20,7 @@ class DatePicker extends InputElement
     /** @var string */
     private $initialDate;
 
-    public function initialDate(string $date): self
+    public function initialDate(string $date): static
     {
         $dateTime = DateTime::createFromFormat(self::DATE_FORMAT, $date);
         if (!$dateTime) {

--- a/src/Inputs/DatePicker.php
+++ b/src/Inputs/DatePicker.php
@@ -20,7 +20,10 @@ class DatePicker extends InputElement
     /** @var string */
     private $initialDate;
 
-    public function initialDate(string $date): static
+    /**
+    * @return static
+    */
+    public function initialDate(string $date)
     {
         $dateTime = DateTime::createFromFormat(self::DATE_FORMAT, $date);
         if (!$dateTime) {

--- a/src/Inputs/HasConfirm.php
+++ b/src/Inputs/HasConfirm.php
@@ -13,9 +13,8 @@ trait HasConfirm
 
     /**
      * @param Confirm $confirm
-     * @return static
      */
-    public function setConfirm(Confirm $confirm): self
+    public function setConfirm(Confirm $confirm): static
     {
         $this->confirm = $confirm->setParent($this);
 
@@ -27,9 +26,8 @@ trait HasConfirm
      * @param string $text
      * @param string $confirm
      * @param string $deny
-     * @return static
      */
-    public function confirm(string $title, string $text, string $confirm = 'OK', string $deny = 'Cancel'): self
+    public function confirm(string $title, string $text, string $confirm = 'OK', string $deny = 'Cancel'): static
     {
         return $this->setConfirm(new Confirm($title, $text, $confirm, $deny));
     }

--- a/src/Inputs/HasConfirm.php
+++ b/src/Inputs/HasConfirm.php
@@ -13,8 +13,9 @@ trait HasConfirm
 
     /**
      * @param Confirm $confirm
+     * @return static
      */
-    public function setConfirm(Confirm $confirm): static
+    public function setConfirm(Confirm $confirm)
     {
         $this->confirm = $confirm->setParent($this);
 
@@ -26,8 +27,9 @@ trait HasConfirm
      * @param string $text
      * @param string $confirm
      * @param string $deny
+     * @return static
      */
-    public function confirm(string $title, string $text, string $confirm = 'OK', string $deny = 'Cancel'): static
+    public function confirm(string $title, string $text, string $confirm = 'OK', string $deny = 'Cancel')
     {
         return $this->setConfirm(new Confirm($title, $text, $confirm, $deny));
     }

--- a/src/Inputs/HasPlaceholder.php
+++ b/src/Inputs/HasPlaceholder.php
@@ -14,8 +14,9 @@ trait HasPlaceholder
 
     /**
      * @param PlainText $placeholder
+     * @return static
      */
-    public function setPlaceholder(PlainText $placeholder): static
+    public function setPlaceholder(PlainText $placeholder)
     {
         $this->placeholder = $placeholder->setParent($this);
 
@@ -24,8 +25,9 @@ trait HasPlaceholder
 
     /**
      * @param string $placeholder
+     * @return static
      */
-    public function placeholder(string $placeholder): static
+    public function placeholder(string $placeholder)
     {
         if (mb_strlen($placeholder, 'UTF-8') > 150) {
             throw new Exception('Placeholder cannot exceed 150 characters');

--- a/src/Inputs/HasPlaceholder.php
+++ b/src/Inputs/HasPlaceholder.php
@@ -14,9 +14,8 @@ trait HasPlaceholder
 
     /**
      * @param PlainText $placeholder
-     * @return static
      */
-    public function setPlaceholder(PlainText $placeholder): self
+    public function setPlaceholder(PlainText $placeholder): static
     {
         $this->placeholder = $placeholder->setParent($this);
 
@@ -25,9 +24,8 @@ trait HasPlaceholder
 
     /**
      * @param string $placeholder
-     * @return static
      */
-    public function placeholder(string $placeholder): self
+    public function placeholder(string $placeholder): static
     {
         if (mb_strlen($placeholder, 'UTF-8') > 150) {
             throw new Exception('Placeholder cannot exceed 150 characters');

--- a/src/Inputs/InputElement.php
+++ b/src/Inputs/InputElement.php
@@ -24,8 +24,9 @@ abstract class InputElement extends Element
 
     /**
      * @param string $actionId
+     * @return static
      */
-    public function actionId(string $actionId): static
+    public function actionId(string $actionId)
     {
         $this->actionId = $actionId;
 

--- a/src/Inputs/InputElement.php
+++ b/src/Inputs/InputElement.php
@@ -24,9 +24,8 @@ abstract class InputElement extends Element
 
     /**
      * @param string $actionId
-     * @return static
      */
-    public function actionId(string $actionId): self
+    public function actionId(string $actionId): static
     {
         $this->actionId = $actionId;
 

--- a/src/Inputs/OverflowMenu.php
+++ b/src/Inputs/OverflowMenu.php
@@ -24,9 +24,8 @@ class OverflowMenu extends InputElement
      * @param string $text
      * @param string $value
      * @param string $url
-     * @return static
      */
-    public function urlOption(string $text, string $value, string $url): self
+    public function urlOption(string $text, string $value, string $url): static
     {
         return $this->addOption(Option::new($text, $value)->url($url));
     }

--- a/src/Inputs/OverflowMenu.php
+++ b/src/Inputs/OverflowMenu.php
@@ -24,8 +24,9 @@ class OverflowMenu extends InputElement
      * @param string $text
      * @param string $value
      * @param string $url
+     * @return static
      */
-    public function urlOption(string $text, string $value, string $url): static
+    public function urlOption(string $text, string $value, string $url)
     {
         return $this->addOption(Option::new($text, $value)->url($url));
     }

--- a/src/Inputs/SelectMenus/ChannelSelectMenu.php
+++ b/src/Inputs/SelectMenus/ChannelSelectMenu.php
@@ -16,8 +16,9 @@ class ChannelSelectMenu extends SelectMenu
 
     /**
      * @param string $initialChannel
+     * @return static
      */
-    public function initialChannel(string $initialChannel): static
+    public function initialChannel(string $initialChannel)
     {
         $this->initialChannel = $initialChannel;
 
@@ -26,8 +27,9 @@ class ChannelSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
+     * @return static
      */
-    public function responseUrlEnabled(bool $enabled): static
+    public function responseUrlEnabled(bool $enabled)
     {
         $this->responseUrlEnabled = $enabled;
 

--- a/src/Inputs/SelectMenus/ChannelSelectMenu.php
+++ b/src/Inputs/SelectMenus/ChannelSelectMenu.php
@@ -16,9 +16,8 @@ class ChannelSelectMenu extends SelectMenu
 
     /**
      * @param string $initialChannel
-     * @return static
      */
-    public function initialChannel(string $initialChannel): self
+    public function initialChannel(string $initialChannel): static
     {
         $this->initialChannel = $initialChannel;
 
@@ -27,9 +26,8 @@ class ChannelSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
-     * @return static
      */
-    public function responseUrlEnabled(bool $enabled): self
+    public function responseUrlEnabled(bool $enabled): static
     {
         $this->responseUrlEnabled = $enabled;
 

--- a/src/Inputs/SelectMenus/ConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/ConversationSelectMenu.php
@@ -23,8 +23,9 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param string $initialConversation
+     * @return static
      */
-    public function initialConversation(string $initialConversation): static
+    public function initialConversation(string $initialConversation)
     {
         $this->initialConversation = $initialConversation;
 
@@ -33,8 +34,9 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
+     * @return static
      */
-    public function responseUrlEnabled(bool $enabled): static
+    public function responseUrlEnabled(bool $enabled)
     {
         $this->responseUrlEnabled = $enabled;
 
@@ -43,8 +45,9 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
+     * @return static
      */
-    public function defaultToCurrentConversation(bool $enabled): static
+    public function defaultToCurrentConversation(bool $enabled)
     {
         $this->defaultToCurrentConversation = $enabled;
 
@@ -53,8 +56,9 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param Filter $filter
+     * @return static
      */
-    public function setFilter(Filter $filter): static
+    public function setFilter(Filter $filter)
     {
         $this->filter = $filter->setParent($this);
 

--- a/src/Inputs/SelectMenus/ConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/ConversationSelectMenu.php
@@ -23,9 +23,8 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param string $initialConversation
-     * @return static
      */
-    public function initialConversation(string $initialConversation): self
+    public function initialConversation(string $initialConversation): static
     {
         $this->initialConversation = $initialConversation;
 
@@ -34,9 +33,8 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
-     * @return static
      */
-    public function responseUrlEnabled(bool $enabled): self
+    public function responseUrlEnabled(bool $enabled): static
     {
         $this->responseUrlEnabled = $enabled;
 
@@ -45,9 +43,8 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param bool $enabled
-     * @return static
      */
-    public function defaultToCurrentConversation(bool $enabled): self
+    public function defaultToCurrentConversation(bool $enabled): static
     {
         $this->defaultToCurrentConversation = $enabled;
 
@@ -56,9 +53,8 @@ class ConversationSelectMenu extends SelectMenu
 
     /**
      * @param Filter $filter
-     * @return static
      */
-    public function setFilter(Filter $filter): self
+    public function setFilter(Filter $filter): static
     {
         $this->filter = $filter->setParent($this);
 

--- a/src/Inputs/SelectMenus/ExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/ExternalSelectMenu.php
@@ -18,8 +18,9 @@ class ExternalSelectMenu extends SelectMenu
     /**
      * @param string $name
      * @param string $value
+     * @return static
      */
-    public function initialOption(string $name, string $value): static
+    public function initialOption(string $name, string $value)
     {
         $this->initialOption = Option::new($name, $value);
         $this->initialOption->setParent($this);
@@ -27,7 +28,10 @@ class ExternalSelectMenu extends SelectMenu
         return $this;
     }
 
-    public function minQueryLength(int $minQueryLength): static
+    /**
+    * @return static
+    */
+    public function minQueryLength(int $minQueryLength)
     {
         $this->minQueryLength = $minQueryLength;
 

--- a/src/Inputs/SelectMenus/ExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/ExternalSelectMenu.php
@@ -18,9 +18,8 @@ class ExternalSelectMenu extends SelectMenu
     /**
      * @param string $name
      * @param string $value
-     * @return self
      */
-    public function initialOption(string $name, string $value): self
+    public function initialOption(string $name, string $value): static
     {
         $this->initialOption = Option::new($name, $value);
         $this->initialOption->setParent($this);
@@ -28,7 +27,7 @@ class ExternalSelectMenu extends SelectMenu
         return $this;
     }
 
-    public function minQueryLength(int $minQueryLength): self
+    public function minQueryLength(int $minQueryLength): static
     {
         $this->minQueryLength = $minQueryLength;
 

--- a/src/Inputs/SelectMenus/MultiChannelSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiChannelSelectMenu.php
@@ -13,9 +13,8 @@ class MultiChannelSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialChannels
-     * @return static
      */
-    public function initialChannels(array $initialChannels): self
+    public function initialChannels(array $initialChannels): static
     {
         $this->initialChannels = $initialChannels;
 

--- a/src/Inputs/SelectMenus/MultiChannelSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiChannelSelectMenu.php
@@ -13,8 +13,9 @@ class MultiChannelSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialChannels
+     * @return static
      */
-    public function initialChannels(array $initialChannels): static
+    public function initialChannels(array $initialChannels)
     {
         $this->initialChannels = $initialChannels;
 

--- a/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
@@ -20,8 +20,9 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialConversations
+     * @return static
      */
-    public function initialConversations(array $initialConversations): static
+    public function initialConversations(array $initialConversations)
     {
         $this->initialConversations = $initialConversations;
 
@@ -30,8 +31,9 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param bool $enabled
+     * @return static
      */
-    public function defaultToCurrentConversation(bool $enabled): static
+    public function defaultToCurrentConversation(bool $enabled)
     {
         $this->defaultToCurrentConversation = $enabled;
 
@@ -40,8 +42,9 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param Filter $filter
+     * @return static
      */
-    public function setFilter(Filter $filter): static
+    public function setFilter(Filter $filter)
     {
         $this->filter = $filter->setParent($this);
 

--- a/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiConversationSelectMenu.php
@@ -20,9 +20,8 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialConversations
-     * @return static
      */
-    public function initialConversations(array $initialConversations): self
+    public function initialConversations(array $initialConversations): static
     {
         $this->initialConversations = $initialConversations;
 
@@ -31,9 +30,8 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param bool $enabled
-     * @return static
      */
-    public function defaultToCurrentConversation(bool $enabled): self
+    public function defaultToCurrentConversation(bool $enabled): static
     {
         $this->defaultToCurrentConversation = $enabled;
 
@@ -42,9 +40,8 @@ class MultiConversationSelectMenu extends MultiSelectMenu
 
     /**
      * @param Filter $filter
-     * @return static
      */
-    public function setFilter(Filter $filter): self
+    public function setFilter(Filter $filter): static
     {
         $this->filter = $filter->setParent($this);
 

--- a/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
@@ -17,8 +17,9 @@ class MultiExternalSelectMenu extends MultiSelectMenu
 
     /**
      * @param array $options
+     * @return static
      */
-    public function initialOptions(array $options): static
+    public function initialOptions(array $options)
     {
         foreach ($options as $name => $value) {
             $option = Option::new((string) $name, (string) $value);
@@ -29,7 +30,10 @@ class MultiExternalSelectMenu extends MultiSelectMenu
         return $this;
     }
 
-    public function minQueryLength(int $minQueryLength): static
+    /**
+    * @return static
+    */
+    public function minQueryLength(int $minQueryLength)
     {
         $this->minQueryLength = $minQueryLength;
 

--- a/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiExternalSelectMenu.php
@@ -17,9 +17,8 @@ class MultiExternalSelectMenu extends MultiSelectMenu
 
     /**
      * @param array $options
-     * @return self
      */
-    public function initialOptions(array $options): self
+    public function initialOptions(array $options): static
     {
         foreach ($options as $name => $value) {
             $option = Option::new((string) $name, (string) $value);
@@ -30,7 +29,7 @@ class MultiExternalSelectMenu extends MultiSelectMenu
         return $this;
     }
 
-    public function minQueryLength(int $minQueryLength): self
+    public function minQueryLength(int $minQueryLength): static
     {
         $this->minQueryLength = $minQueryLength;
 

--- a/src/Inputs/SelectMenus/MultiSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiSelectMenu.php
@@ -13,8 +13,9 @@ abstract class MultiSelectMenu extends SelectMenu
 
     /**
      * @param int $maxSelectedItems
+     * @return static
      */
-    public function maxSelectedItems(int $maxSelectedItems): static
+    public function maxSelectedItems(int $maxSelectedItems)
     {
         $this->maxSelectedItems = $maxSelectedItems;
 
@@ -24,8 +25,9 @@ abstract class MultiSelectMenu extends SelectMenu
     /**
      * @param int $maxSelectedItems
      * @deprecated Inconsistent method name. Use MultiSelectMenu::maxSelectedItems() instead.
+     * @return static
      */
-    public function setMaxSelectedItems(int $maxSelectedItems): static
+    public function setMaxSelectedItems(int $maxSelectedItems)
     {
         $this->maxSelectedItems = $maxSelectedItems;
 

--- a/src/Inputs/SelectMenus/MultiSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiSelectMenu.php
@@ -13,9 +13,8 @@ abstract class MultiSelectMenu extends SelectMenu
 
     /**
      * @param int $maxSelectedItems
-     * @return static
      */
-    public function maxSelectedItems(int $maxSelectedItems): self
+    public function maxSelectedItems(int $maxSelectedItems): static
     {
         $this->maxSelectedItems = $maxSelectedItems;
 
@@ -24,10 +23,9 @@ abstract class MultiSelectMenu extends SelectMenu
 
     /**
      * @param int $maxSelectedItems
-     * @return static
      * @deprecated Inconsistent method name. Use MultiSelectMenu::maxSelectedItems() instead.
      */
-    public function setMaxSelectedItems(int $maxSelectedItems): self
+    public function setMaxSelectedItems(int $maxSelectedItems): static
     {
         $this->maxSelectedItems = $maxSelectedItems;
 

--- a/src/Inputs/SelectMenus/MultiUserSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiUserSelectMenu.php
@@ -13,8 +13,9 @@ class MultiUserSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialUsers
+     * @return static
      */
-    public function initialUsers(array $initialUsers): static
+    public function initialUsers(array $initialUsers)
     {
         $this->initialUsers = $initialUsers;
 

--- a/src/Inputs/SelectMenus/MultiUserSelectMenu.php
+++ b/src/Inputs/SelectMenus/MultiUserSelectMenu.php
@@ -13,9 +13,8 @@ class MultiUserSelectMenu extends MultiSelectMenu
 
     /**
      * @param string[] $initialUsers
-     * @return static
      */
-    public function initialUsers(array $initialUsers): self
+    public function initialUsers(array $initialUsers): static
     {
         $this->initialUsers = $initialUsers;
 

--- a/src/Inputs/SelectMenus/UserSelectMenu.php
+++ b/src/Inputs/SelectMenus/UserSelectMenu.php
@@ -13,8 +13,9 @@ class UserSelectMenu extends SelectMenu
 
     /**
      * @param string $initialUser
+     * @return static
      */
-    public function initialUser(string $initialUser): static
+    public function initialUser(string $initialUser)
     {
         $this->initialUser = $initialUser;
 

--- a/src/Inputs/SelectMenus/UserSelectMenu.php
+++ b/src/Inputs/SelectMenus/UserSelectMenu.php
@@ -13,9 +13,8 @@ class UserSelectMenu extends SelectMenu
 
     /**
      * @param string $initialUser
-     * @return static
      */
-    public function initialUser(string $initialUser): self
+    public function initialUser(string $initialUser): static
     {
         $this->initialUser = $initialUser;
 

--- a/src/Inputs/TextInput.php
+++ b/src/Inputs/TextInput.php
@@ -29,21 +29,21 @@ class TextInput extends InputElement
     /** @var DispatchActionConfig */
     private $dispatchActionConfig;
 
-    public function initialValue(string $text): self
+    public function initialValue(string $text): static
     {
         $this->initialValue = $text;
 
         return $this;
     }
 
-    public function multiline(bool $flag): self
+    public function multiline(bool $flag): static
     {
         $this->multiline = $flag;
 
         return $this;
     }
 
-    public function minLength(int $length): self
+    public function minLength(int $length): static
     {
         if ($length < 0) {
             throw new Exception('Min length must be >= 0');
@@ -54,7 +54,7 @@ class TextInput extends InputElement
         return $this;
     }
 
-    public function maxLength(int $length): self
+    public function maxLength(int $length): static
     {
         if ($length < 1) {
             throw new Exception('Max length must be >= 1');
@@ -65,14 +65,14 @@ class TextInput extends InputElement
         return $this;
     }
 
-    public function setDispatchActionConfig(DispatchActionConfig $config): self
+    public function setDispatchActionConfig(DispatchActionConfig $config): static
     {
         $this->dispatchActionConfig = $config;
 
         return $this;
     }
 
-    public function triggerActionOnEnterPressed(): self
+    public function triggerActionOnEnterPressed(): static
     {
         $config = $this->dispatchActionConfig ?? DispatchActionConfig::new();
         $config->triggerActionsOnEnterPressed();
@@ -80,7 +80,7 @@ class TextInput extends InputElement
         return $this->setDispatchActionConfig($config);
     }
 
-    public function triggerActionOnCharacterEntered(): self
+    public function triggerActionOnCharacterEntered(): static
     {
         $config = $this->dispatchActionConfig ?? DispatchActionConfig::new();
         $config->triggerActionsOnCharacterEntered();

--- a/src/Inputs/TextInput.php
+++ b/src/Inputs/TextInput.php
@@ -29,21 +29,30 @@ class TextInput extends InputElement
     /** @var DispatchActionConfig */
     private $dispatchActionConfig;
 
-    public function initialValue(string $text): static
+    /**
+    * @return static
+    */
+    public function initialValue(string $text)
     {
         $this->initialValue = $text;
 
         return $this;
     }
 
-    public function multiline(bool $flag): static
+    /**
+    * @return static
+    */
+    public function multiline(bool $flag)
     {
         $this->multiline = $flag;
 
         return $this;
     }
 
-    public function minLength(int $length): static
+    /**
+    * @return static
+    */
+    public function minLength(int $length)
     {
         if ($length < 0) {
             throw new Exception('Min length must be >= 0');
@@ -54,7 +63,10 @@ class TextInput extends InputElement
         return $this;
     }
 
-    public function maxLength(int $length): static
+    /**
+    * @return static
+    */
+    public function maxLength(int $length)
     {
         if ($length < 1) {
             throw new Exception('Max length must be >= 1');
@@ -65,14 +77,20 @@ class TextInput extends InputElement
         return $this;
     }
 
-    public function setDispatchActionConfig(DispatchActionConfig $config): static
+    /**
+    * @return static
+    */
+    public function setDispatchActionConfig(DispatchActionConfig $config)
     {
         $this->dispatchActionConfig = $config;
 
         return $this;
     }
 
-    public function triggerActionOnEnterPressed(): static
+    /**
+    * @return static
+    */
+    public function triggerActionOnEnterPressed()
     {
         $config = $this->dispatchActionConfig ?? DispatchActionConfig::new();
         $config->triggerActionsOnEnterPressed();
@@ -80,7 +98,10 @@ class TextInput extends InputElement
         return $this->setDispatchActionConfig($config);
     }
 
-    public function triggerActionOnCharacterEntered(): static
+    /**
+    * @return static
+    */
+    public function triggerActionOnCharacterEntered()
     {
         $config = $this->dispatchActionConfig ?? DispatchActionConfig::new();
         $config->triggerActionsOnCharacterEntered();

--- a/src/Inputs/TimePicker.php
+++ b/src/Inputs/TimePicker.php
@@ -20,7 +20,10 @@ class TimePicker extends InputElement
     /** @var string */
     private $initialTime;
 
-    public function initialTime(string $time): static
+    /**
+    * @return static
+    */
+    public function initialTime(string $time)
     {
         $dateTime = DateTime::createFromFormat(self::TIME_FORMAT, $time);
         if (!$dateTime) {

--- a/src/Inputs/TimePicker.php
+++ b/src/Inputs/TimePicker.php
@@ -20,7 +20,7 @@ class TimePicker extends InputElement
     /** @var string */
     private $initialTime;
 
-    public function initialTime(string $time): self
+    public function initialTime(string $time): static
     {
         $dateTime = DateTime::createFromFormat(self::TIME_FORMAT, $time);
         if (!$dateTime) {

--- a/src/Partials/Confirm.php
+++ b/src/Partials/Confirm.php
@@ -40,8 +40,9 @@ class Confirm extends Element
 
     /**
      * @param PlainText $title
+     * @return static
      */
-    public function setTitle(PlainText $title): static
+    public function setTitle(PlainText $title)
     {
         $this->title = $title->setParent($this);
 
@@ -50,8 +51,9 @@ class Confirm extends Element
 
     /**
      * @param Text $text
+     * @return static
      */
-    public function setText(Text $text): static
+    public function setText(Text $text)
     {
         $this->text = $text->setParent($this);
 
@@ -60,8 +62,9 @@ class Confirm extends Element
 
     /**
      * @param PlainText $confirm
+     * @return static
      */
-    public function setConfirm(PlainText $confirm): static
+    public function setConfirm(PlainText $confirm)
     {
         $this->confirm = $confirm->setParent($this);
 
@@ -70,8 +73,9 @@ class Confirm extends Element
 
     /**
      * @param PlainText $deny
+     * @return static
      */
-    public function setDeny(PlainText $deny): static
+    public function setDeny(PlainText $deny)
     {
         $this->deny = $deny->setParent($this);
 
@@ -80,32 +84,36 @@ class Confirm extends Element
 
     /**
      * @param string $title
+     * @return static
      */
-    public function title(string $title): static
+    public function title(string $title)
     {
         return $this->setTitle(new PlainText($title));
     }
 
     /**
      * @param string $text
+     * @return static
      */
-    public function text(string $text): static
+    public function text(string $text)
     {
         return $this->setText(new MrkdwnText($text));
     }
 
     /**
      * @param string $confirm
+     * @return static
      */
-    public function confirm(string $confirm): static
+    public function confirm(string $confirm)
     {
         return $this->setConfirm(new PlainText($confirm));
     }
 
     /**
      * @param string $deny
+     * @return static
      */
-    public function deny(string $deny): static
+    public function deny(string $deny)
     {
         return $this->setDeny(new PlainText($deny));
     }

--- a/src/Partials/Confirm.php
+++ b/src/Partials/Confirm.php
@@ -40,9 +40,8 @@ class Confirm extends Element
 
     /**
      * @param PlainText $title
-     * @return static
      */
-    public function setTitle(PlainText $title): self
+    public function setTitle(PlainText $title): static
     {
         $this->title = $title->setParent($this);
 
@@ -51,9 +50,8 @@ class Confirm extends Element
 
     /**
      * @param Text $text
-     * @return static
      */
-    public function setText(Text $text): self
+    public function setText(Text $text): static
     {
         $this->text = $text->setParent($this);
 
@@ -62,9 +60,8 @@ class Confirm extends Element
 
     /**
      * @param PlainText $confirm
-     * @return static
      */
-    public function setConfirm(PlainText $confirm): self
+    public function setConfirm(PlainText $confirm): static
     {
         $this->confirm = $confirm->setParent($this);
 
@@ -73,9 +70,8 @@ class Confirm extends Element
 
     /**
      * @param PlainText $deny
-     * @return static
      */
-    public function setDeny(PlainText $deny): self
+    public function setDeny(PlainText $deny): static
     {
         $this->deny = $deny->setParent($this);
 
@@ -84,36 +80,32 @@ class Confirm extends Element
 
     /**
      * @param string $title
-     * @return static
      */
-    public function title(string $title): self
+    public function title(string $title): static
     {
         return $this->setTitle(new PlainText($title));
     }
 
     /**
      * @param string $text
-     * @return static
      */
-    public function text(string $text): self
+    public function text(string $text): static
     {
         return $this->setText(new MrkdwnText($text));
     }
 
     /**
      * @param string $confirm
-     * @return static
      */
-    public function confirm(string $confirm): self
+    public function confirm(string $confirm): static
     {
         return $this->setConfirm(new PlainText($confirm));
     }
 
     /**
      * @param string $deny
-     * @return static
      */
-    public function deny(string $deny): self
+    public function deny(string $deny): static
     {
         return $this->setDeny(new PlainText($deny));
     }

--- a/src/Partials/DispatchActionConfig.php
+++ b/src/Partials/DispatchActionConfig.php
@@ -16,27 +16,20 @@ class DispatchActionConfig extends Element
 
     /**
      * @param string $eventType
-     * @return static
      */
-    public function triggerActionsOn(string $eventType): self
+    public function triggerActionsOn(string $eventType): static
     {
         $this->triggerActionsOn[] = $eventType;
 
         return $this;
     }
 
-    /**
-     * @return static
-     */
-    public function triggerActionsOnEnterPressed(): self
+    public function triggerActionsOnEnterPressed(): static
     {
         return $this->triggerActionsOn(self::ON_ENTER_PRESSED);
     }
 
-    /**
-     * @return static
-     */
-    public function triggerActionsOnCharacterEntered(): self
+    public function triggerActionsOnCharacterEntered(): static
     {
         return $this->triggerActionsOn(self::ON_CHARACTER_ENTERED);
     }

--- a/src/Partials/DispatchActionConfig.php
+++ b/src/Partials/DispatchActionConfig.php
@@ -16,20 +16,27 @@ class DispatchActionConfig extends Element
 
     /**
      * @param string $eventType
+     * @return static
      */
-    public function triggerActionsOn(string $eventType): static
+    public function triggerActionsOn(string $eventType)
     {
         $this->triggerActionsOn[] = $eventType;
 
         return $this;
     }
 
-    public function triggerActionsOnEnterPressed(): static
+    /**
+    * @return static
+    */
+    public function triggerActionsOnEnterPressed()
     {
         return $this->triggerActionsOn(self::ON_ENTER_PRESSED);
     }
 
-    public function triggerActionsOnCharacterEntered(): static
+    /**
+    * @return static
+    */
+    public function triggerActionsOnCharacterEntered()
     {
         return $this->triggerActionsOn(self::ON_CHARACTER_ENTERED);
     }

--- a/src/Partials/Fields.php
+++ b/src/Partials/Fields.php
@@ -23,8 +23,9 @@ class Fields extends Element
 
     /**
      * @param Text $field
+     * @return static
      */
-    public function add(Text $field): static
+    public function add(Text $field)
     {
         if (count($this->fields) >= 10) {
             throw new Exception('Cannot have more than 10 fields');
@@ -37,8 +38,9 @@ class Fields extends Element
 
     /**
      * @param Text[]|string[] $fields
+     * @return static
      */
-    public function populate(array $fields = []): static
+    public function populate(array $fields = [])
     {
         foreach ($fields as $field) {
             if (!$field instanceof Text) {

--- a/src/Partials/Fields.php
+++ b/src/Partials/Fields.php
@@ -23,9 +23,8 @@ class Fields extends Element
 
     /**
      * @param Text $field
-     * @return self
      */
-    public function add(Text $field): self
+    public function add(Text $field): static
     {
         if (count($this->fields) >= 10) {
             throw new Exception('Cannot have more than 10 fields');
@@ -38,9 +37,8 @@ class Fields extends Element
 
     /**
      * @param Text[]|string[] $fields
-     * @return self
      */
-    public function populate(array $fields = []): self
+    public function populate(array $fields = []): static
     {
         foreach ($fields as $field) {
             if (!$field instanceof Text) {

--- a/src/Partials/Filter.php
+++ b/src/Partials/Filter.php
@@ -24,8 +24,9 @@ class Filter extends Element
 
     /**
      * @param string $conversationType
+     * @return static
      */
-    public function includeType(string $conversationType): static
+    public function includeType(string $conversationType)
     {
         $this->include[] = $conversationType;
 
@@ -34,38 +35,52 @@ class Filter extends Element
 
     /**
      * @param string[] $conversationTypes
+     * @return static
      */
-    public function includeTypes(array $conversationTypes): static
+    public function includeTypes(array $conversationTypes)
     {
         $this->include = $conversationTypes;
 
         return $this;
     }
 
-    public function includeIm(): static
+    /**
+    * @return static
+    */
+    public function includeIm()
     {
         return $this->includeType(self::CONVERSATION_TYPE_IM);
     }
 
-    public function includeMpim(): static
+    /**
+    * @return static
+    */
+    public function includeMpim()
     {
         return $this->includeType(self::CONVERSATION_TYPE_MPIM);
     }
 
-    public function includePrivate(): static
+    /**
+    * @return static
+    */
+    public function includePrivate()
     {
         return $this->includeType(self::CONVERSATION_TYPE_PRIVATE);
     }
 
-    public function includePublic(): static
+    /**
+    * @return static
+    */
+    public function includePublic()
     {
         return $this->includeType(self::CONVERSATION_TYPE_PUBLIC);
     }
 
     /**
      * @param bool $excludeBotUsers
+     * @return static
      */
-    public function excludeBotUsers(bool $excludeBotUsers): static
+    public function excludeBotUsers(bool $excludeBotUsers)
     {
         $this->excludeBotUsers = $excludeBotUsers;
 
@@ -74,8 +89,9 @@ class Filter extends Element
 
     /**
      * @param bool $excludeExternalSharedChannels
+     * @return static
      */
-    public function excludeExternalSharedChannels(bool $excludeExternalSharedChannels): static
+    public function excludeExternalSharedChannels(bool $excludeExternalSharedChannels)
     {
         $this->excludeExternalSharedChannels = $excludeExternalSharedChannels;
 

--- a/src/Partials/Filter.php
+++ b/src/Partials/Filter.php
@@ -24,9 +24,8 @@ class Filter extends Element
 
     /**
      * @param string $conversationType
-     * @return static
      */
-    public function includeType(string $conversationType): self
+    public function includeType(string $conversationType): static
     {
         $this->include[] = $conversationType;
 
@@ -35,52 +34,38 @@ class Filter extends Element
 
     /**
      * @param string[] $conversationTypes
-     * @return static
      */
-    public function includeTypes(array $conversationTypes): self
+    public function includeTypes(array $conversationTypes): static
     {
         $this->include = $conversationTypes;
 
         return $this;
     }
 
-    /**
-     * @return static
-     */
-    public function includeIm(): self
+    public function includeIm(): static
     {
         return $this->includeType(self::CONVERSATION_TYPE_IM);
     }
 
-    /**
-     * @return static
-     */
-    public function includeMpim(): self
+    public function includeMpim(): static
     {
         return $this->includeType(self::CONVERSATION_TYPE_MPIM);
     }
 
-    /**
-     * @return static
-     */
-    public function includePrivate(): self
+    public function includePrivate(): static
     {
         return $this->includeType(self::CONVERSATION_TYPE_PRIVATE);
     }
 
-    /**
-     * @return static
-     */
-    public function includePublic(): self
+    public function includePublic(): static
     {
         return $this->includeType(self::CONVERSATION_TYPE_PUBLIC);
     }
 
     /**
      * @param bool $excludeBotUsers
-     * @return static
      */
-    public function excludeBotUsers(bool $excludeBotUsers): self
+    public function excludeBotUsers(bool $excludeBotUsers): static
     {
         $this->excludeBotUsers = $excludeBotUsers;
 
@@ -89,9 +74,8 @@ class Filter extends Element
 
     /**
      * @param bool $excludeExternalSharedChannels
-     * @return static
      */
-    public function excludeExternalSharedChannels(bool $excludeExternalSharedChannels): self
+    public function excludeExternalSharedChannels(bool $excludeExternalSharedChannels): static
     {
         $this->excludeExternalSharedChannels = $excludeExternalSharedChannels;
 

--- a/src/Partials/HasOptionGroups.php
+++ b/src/Partials/HasOptionGroups.php
@@ -16,8 +16,9 @@ trait HasOptionGroups
 
     /**
      * @param OptionGroup $group
+     * @return static
      */
-    public function addOptionGroup(OptionGroup $group): static
+    public function addOptionGroup(OptionGroup $group)
     {
         $group->setParent($this);
         $this->optionGroups[] = $group;
@@ -27,8 +28,9 @@ trait HasOptionGroups
 
     /**
      * @param array<string, array<string, string>|string[]> $optionGroups
+     * @return static
      */
-    public function optionGroups(array $optionGroups): static
+    public function optionGroups(array $optionGroups)
     {
         foreach ($optionGroups as $label => $options) {
             $this->optionGroup((string) $label, $options);
@@ -40,8 +42,9 @@ trait HasOptionGroups
     /**
      * @param string $label
      * @param array<string, string>|string[] $options
+     * @return static
      */
-    public function optionGroup(string $label, array $options): static
+    public function optionGroup(string $label, array $options)
     {
         return $this->addOptionGroup(OptionGroup::new($label, $options));
     }

--- a/src/Partials/HasOptionGroups.php
+++ b/src/Partials/HasOptionGroups.php
@@ -16,9 +16,8 @@ trait HasOptionGroups
 
     /**
      * @param OptionGroup $group
-     * @return static
      */
-    public function addOptionGroup(OptionGroup $group): self
+    public function addOptionGroup(OptionGroup $group): static
     {
         $group->setParent($this);
         $this->optionGroups[] = $group;
@@ -28,9 +27,8 @@ trait HasOptionGroups
 
     /**
      * @param array<string, array<string, string>|string[]> $optionGroups
-     * @return static
      */
-    public function optionGroups(array $optionGroups): self
+    public function optionGroups(array $optionGroups): static
     {
         foreach ($optionGroups as $label => $options) {
             $this->optionGroup((string) $label, $options);
@@ -42,9 +40,8 @@ trait HasOptionGroups
     /**
      * @param string $label
      * @param array<string, string>|string[] $options
-     * @return static
      */
-    public function optionGroup(string $label, array $options): self
+    public function optionGroup(string $label, array $options): static
     {
         return $this->addOptionGroup(OptionGroup::new($label, $options));
     }

--- a/src/Partials/HasOptions.php
+++ b/src/Partials/HasOptions.php
@@ -41,9 +41,8 @@ trait HasOptions
     /**
      * @param Option $option
      * @param bool $isInitial
-     * @return static
      */
-    public function addOption(Option $option, bool $isInitial = false): self
+    public function addOption(Option $option, bool $isInitial = false): static
     {
         $option->setParent($this);
         $this->options[] = $option;
@@ -57,9 +56,8 @@ trait HasOptions
 
     /**
      * @param Option[] $options
-     * @return static
      */
-    public function addOptions(array $options): self
+    public function addOptions(array $options): static
     {
         foreach ($options as $option) {
             $this->addOption($option);
@@ -72,18 +70,16 @@ trait HasOptions
      * @param string $text
      * @param string $value
      * @param bool $isInitial
-     * @return static
      */
-    public function option(string $text, string $value, bool $isInitial = false): self
+    public function option(string $text, string $value, bool $isInitial = false): static
     {
         return $this->addOption(Option::new($text, $value), $isInitial);
     }
 
     /**
      * @param array<string, string>|string[] $options
-     * @return static
      */
-    public function options(array $options): self
+    public function options(array $options): static
     {
         foreach ($options as $text => $value) {
             $value = (string) $value;
@@ -97,9 +93,8 @@ trait HasOptions
     /**
      * @param string $text
      * @param string $value
-     * @return self
      */
-    public function initialOption(string $text, string $value): self
+    public function initialOption(string $text, string $value): static
     {
         $initialOption = Option::new($text, $value);
         $initialOption->setParent($this);
@@ -110,9 +105,8 @@ trait HasOptions
 
     /**
      * @param array<string, string>|string[] $options
-     * @return self
      */
-    public function initialOptions(array $options): self
+    public function initialOptions(array $options): static
     {
         foreach ($options as $text => $value) {
             $value = (string) $value;

--- a/src/Partials/HasOptions.php
+++ b/src/Partials/HasOptions.php
@@ -41,8 +41,9 @@ trait HasOptions
     /**
      * @param Option $option
      * @param bool $isInitial
+     * @return static
      */
-    public function addOption(Option $option, bool $isInitial = false): static
+    public function addOption(Option $option, bool $isInitial = false)
     {
         $option->setParent($this);
         $this->options[] = $option;
@@ -56,8 +57,9 @@ trait HasOptions
 
     /**
      * @param Option[] $options
+     * @return static
      */
-    public function addOptions(array $options): static
+    public function addOptions(array $options)
     {
         foreach ($options as $option) {
             $this->addOption($option);
@@ -70,16 +72,18 @@ trait HasOptions
      * @param string $text
      * @param string $value
      * @param bool $isInitial
+     * @return static
      */
-    public function option(string $text, string $value, bool $isInitial = false): static
+    public function option(string $text, string $value, bool $isInitial = false)
     {
         return $this->addOption(Option::new($text, $value), $isInitial);
     }
 
     /**
      * @param array<string, string>|string[] $options
+     * @return static
      */
-    public function options(array $options): static
+    public function options(array $options)
     {
         foreach ($options as $text => $value) {
             $value = (string) $value;
@@ -93,8 +97,9 @@ trait HasOptions
     /**
      * @param string $text
      * @param string $value
+     * @return static
      */
-    public function initialOption(string $text, string $value): static
+    public function initialOption(string $text, string $value)
     {
         $initialOption = Option::new($text, $value);
         $initialOption->setParent($this);
@@ -105,8 +110,9 @@ trait HasOptions
 
     /**
      * @param array<string, string>|string[] $options
+     * @return static
      */
-    public function initialOptions(array $options): static
+    public function initialOptions(array $options)
     {
         foreach ($options as $text => $value) {
             $value = (string) $value;

--- a/src/Partials/MrkdwnText.php
+++ b/src/Partials/MrkdwnText.php
@@ -28,8 +28,9 @@ class MrkdwnText extends Text
 
     /**
      * @param bool|null $verbatim
+     * @return static
      */
-    public function verbatim(?bool $verbatim): static
+    public function verbatim(?bool $verbatim)
     {
         $this->verbatim = $verbatim;
 

--- a/src/Partials/MrkdwnText.php
+++ b/src/Partials/MrkdwnText.php
@@ -28,9 +28,8 @@ class MrkdwnText extends Text
 
     /**
      * @param bool|null $verbatim
-     * @return static
      */
-    public function verbatim(?bool $verbatim): self
+    public function verbatim(?bool $verbatim): static
     {
         $this->verbatim = $verbatim;
 

--- a/src/Partials/Option.php
+++ b/src/Partials/Option.php
@@ -26,11 +26,10 @@ class Option extends Element
     /**
      * @param string|null $text
      * @param string|null $value
-     * @return self
      */
-    public static function new(?string $text = null, ?string $value = null): self
+    public static function new(?string $text = null, ?string $value = null): static
     {
-        $option = new self();
+        $option = new static();
 
         if ($text !== null) {
             $option->text($text);
@@ -45,9 +44,8 @@ class Option extends Element
 
     /**
      * @param PlainText $text
-     * @return static
      */
-    public function setText(PlainText $text): self
+    public function setText(PlainText $text): static
     {
         $this->text = $text->setParent($this);
 
@@ -56,18 +54,16 @@ class Option extends Element
 
     /**
      * @param string $text
-     * @return static
      */
-    public function text(string $text): self
+    public function text(string $text): static
     {
         return $this->setText(new PlainText($text));
     }
 
     /**
      * @param string $value
-     * @return static
      */
-    public function value(string $value): self
+    public function value(string $value): static
     {
         $this->value = $value;
 
@@ -76,9 +72,8 @@ class Option extends Element
 
     /**
      * @param PlainText $description
-     * @return static
      */
-    public function setDescription(PlainText $description): self
+    public function setDescription(PlainText $description): static
     {
         $this->description = $description->setParent($this);
 
@@ -87,18 +82,16 @@ class Option extends Element
 
     /**
      * @param string $description
-     * @return static
      */
-    public function description(string $description): self
+    public function description(string $description): static
     {
         return $this->setDescription(new PlainText($description));
     }
 
     /**
      * @param string $url
-     * @return static
      */
-    public function url(string $url): self
+    public function url(string $url): static
     {
         $this->url = $url;
 

--- a/src/Partials/Option.php
+++ b/src/Partials/Option.php
@@ -26,8 +26,9 @@ class Option extends Element
     /**
      * @param string|null $text
      * @param string|null $value
+     * @return static
      */
-    public static function new(?string $text = null, ?string $value = null): static
+    public static function new(?string $text = null, ?string $value = null)
     {
         $option = new static();
 
@@ -44,8 +45,9 @@ class Option extends Element
 
     /**
      * @param PlainText $text
+     * @return static
      */
-    public function setText(PlainText $text): static
+    public function setText(PlainText $text)
     {
         $this->text = $text->setParent($this);
 
@@ -54,16 +56,18 @@ class Option extends Element
 
     /**
      * @param string $text
+     * @return static
      */
-    public function text(string $text): static
+    public function text(string $text)
     {
         return $this->setText(new PlainText($text));
     }
 
     /**
      * @param string $value
+     * @return static
      */
-    public function value(string $value): static
+    public function value(string $value)
     {
         $this->value = $value;
 
@@ -72,8 +76,9 @@ class Option extends Element
 
     /**
      * @param PlainText $description
+     * @return static
      */
-    public function setDescription(PlainText $description): static
+    public function setDescription(PlainText $description)
     {
         $this->description = $description->setParent($this);
 
@@ -82,16 +87,18 @@ class Option extends Element
 
     /**
      * @param string $description
+     * @return static
      */
-    public function description(string $description): static
+    public function description(string $description)
     {
         return $this->setDescription(new PlainText($description));
     }
 
     /**
      * @param string $url
+     * @return static
      */
-    public function url(string $url): static
+    public function url(string $url)
     {
         $this->url = $url;
 

--- a/src/Partials/OptionGroup.php
+++ b/src/Partials/OptionGroup.php
@@ -16,8 +16,9 @@ class OptionGroup extends Element
     /**
      * @param string|null $label
      * @param array<string, string>|string[]|null $options
+     * @return static
      */
-    public static function new(?string $label = null, ?array $options = null): static
+    public static function new(?string $label = null, ?array $options = null)
     {
         $optionGroup = new static();
 
@@ -39,8 +40,9 @@ class OptionGroup extends Element
 
     /**
      * @param PlainText $label
+     * @return static
      */
-    public function setLabel(PlainText $label): static
+    public function setLabel(PlainText $label)
     {
         $this->label = $label->setParent($this);
 
@@ -49,8 +51,9 @@ class OptionGroup extends Element
 
     /**
      * @param string $label
+     * @return static
      */
-    public function label(string $label): static
+    public function label(string $label)
     {
         return $this->setLabel(new PlainText($label, false));
     }

--- a/src/Partials/OptionGroup.php
+++ b/src/Partials/OptionGroup.php
@@ -16,11 +16,10 @@ class OptionGroup extends Element
     /**
      * @param string|null $label
      * @param array<string, string>|string[]|null $options
-     * @return self
      */
-    public static function new(?string $label = null, ?array $options = null): self
+    public static function new(?string $label = null, ?array $options = null): static
     {
-        $optionGroup = new self();
+        $optionGroup = new static();
 
         if ($label !== null) {
             $optionGroup->label($label);
@@ -40,9 +39,8 @@ class OptionGroup extends Element
 
     /**
      * @param PlainText $label
-     * @return static
      */
-    public function setLabel(PlainText $label): self
+    public function setLabel(PlainText $label): static
     {
         $this->label = $label->setParent($this);
 
@@ -51,9 +49,8 @@ class OptionGroup extends Element
 
     /**
      * @param string $label
-     * @return static
      */
-    public function label(string $label): self
+    public function label(string $label): static
     {
         return $this->setLabel(new PlainText($label, false));
     }

--- a/src/Partials/OptionsConfig.php
+++ b/src/Partials/OptionsConfig.php
@@ -15,9 +15,9 @@ class OptionsConfig
     /** @var int|null Maximum number of initial options supported. */
     private $maxInitialOptions;
 
-    public static function new(): self
+    public static function new(): static
     {
-        return new self();
+        return new static();
     }
 
     public function __construct()
@@ -35,9 +35,8 @@ class OptionsConfig
 
     /**
      * @param int|null $minOptions
-     * @return self
      */
-    public function setMinOptions(?int $minOptions): self
+    public function setMinOptions(?int $minOptions): static
     {
         $this->minOptions = $minOptions;
 
@@ -54,9 +53,8 @@ class OptionsConfig
 
     /**
      * @param int|null $maxOptions
-     * @return self
      */
-    public function setMaxOptions(?int $maxOptions): self
+    public function setMaxOptions(?int $maxOptions): static
     {
         $this->maxOptions = $maxOptions;
 
@@ -73,9 +71,8 @@ class OptionsConfig
 
     /**
      * @param int|null $maxInitialOptions
-     * @return self
      */
-    public function setMaxInitialOptions(?int $maxInitialOptions): self
+    public function setMaxInitialOptions(?int $maxInitialOptions): static
     {
         $this->maxInitialOptions = $maxInitialOptions;
 

--- a/src/Partials/OptionsConfig.php
+++ b/src/Partials/OptionsConfig.php
@@ -15,7 +15,10 @@ class OptionsConfig
     /** @var int|null Maximum number of initial options supported. */
     private $maxInitialOptions;
 
-    public static function new(): static
+    /**
+    * @return static
+    */
+    public static function new()
     {
         return new static();
     }
@@ -35,8 +38,9 @@ class OptionsConfig
 
     /**
      * @param int|null $minOptions
+     * @return static
      */
-    public function setMinOptions(?int $minOptions): static
+    public function setMinOptions(?int $minOptions)
     {
         $this->minOptions = $minOptions;
 
@@ -53,8 +57,9 @@ class OptionsConfig
 
     /**
      * @param int|null $maxOptions
+     * @return static
      */
-    public function setMaxOptions(?int $maxOptions): static
+    public function setMaxOptions(?int $maxOptions)
     {
         $this->maxOptions = $maxOptions;
 
@@ -71,8 +76,9 @@ class OptionsConfig
 
     /**
      * @param int|null $maxInitialOptions
+     * @return static
      */
-    public function setMaxInitialOptions(?int $maxInitialOptions): static
+    public function setMaxInitialOptions(?int $maxInitialOptions)
     {
         $this->maxInitialOptions = $maxInitialOptions;
 

--- a/src/Partials/PlainText.php
+++ b/src/Partials/PlainText.php
@@ -28,9 +28,8 @@ class PlainText extends Text
 
     /**
      * @param bool|null $emoji
-     * @return static
      */
-    public function emoji(?bool $emoji): self
+    public function emoji(?bool $emoji): static
     {
         $this->emoji = $emoji;
 

--- a/src/Partials/PlainText.php
+++ b/src/Partials/PlainText.php
@@ -28,8 +28,9 @@ class PlainText extends Text
 
     /**
      * @param bool|null $emoji
+     * @return static
      */
-    public function emoji(?bool $emoji): static
+    public function emoji(?bool $emoji)
     {
         $this->emoji = $emoji;
 

--- a/src/Partials/Text.php
+++ b/src/Partials/Text.php
@@ -13,9 +13,8 @@ abstract class Text extends Element
 
     /**
      * @param string $text
-     * @return static
      */
-    public function text(string $text): self
+    public function text(string $text): static
     {
         $this->text = $text;
 

--- a/src/Partials/Text.php
+++ b/src/Partials/Text.php
@@ -13,8 +13,9 @@ abstract class Text extends Element
 
     /**
      * @param string $text
+     * @return static
      */
-    public function text(string $text): static
+    public function text(string $text)
     {
         $this->text = $text;
 

--- a/src/Previewer.php
+++ b/src/Previewer.php
@@ -15,9 +15,9 @@ final class Previewer
 {
     private const BUILDER_URL = 'https://app.slack.com/block-kit-builder';
 
-    public static function new(): self
+    public static function new(): static
     {
-        return new self();
+        return new static();
     }
 
     public function preview(Surfaces\Surface $surface): string

--- a/src/Previewer.php
+++ b/src/Previewer.php
@@ -15,7 +15,10 @@ final class Previewer
 {
     private const BUILDER_URL = 'https://app.slack.com/block-kit-builder';
 
-    public static function new(): static
+    /**
+    * @return static
+    */
+    public static function new()
     {
         return new static();
     }

--- a/src/Surfaces/Attachment.php
+++ b/src/Surfaces/Attachment.php
@@ -38,9 +38,8 @@ class Attachment extends Surface
      * This makes sure the `#` is included in the color, in case you forget it.
      *
      * @param string $color
-     * @return Attachment
      */
-    public function color(string $color): self
+    public function color(string $color): static
     {
         $this->color = '#' . ltrim($color, '#');
 

--- a/src/Surfaces/Attachment.php
+++ b/src/Surfaces/Attachment.php
@@ -38,8 +38,9 @@ class Attachment extends Surface
      * This makes sure the `#` is included in the color, in case you forget it.
      *
      * @param string $color
+     * @return static
      */
-    public function color(string $color): static
+    public function color(string $color)
     {
         $this->color = '#' . ltrim($color, '#');
 

--- a/src/Surfaces/Message.php
+++ b/src/Surfaces/Message.php
@@ -40,8 +40,9 @@ class Message extends Surface
      *
      * This is default behavior for most interactions, and doesn't necessarily need to be explicitly configured.
      *
+     * @return static
      */
-    public function ephemeral(): static
+    public function ephemeral()
     {
         return $this->directives(self::EPHEMERAL);
     }
@@ -49,8 +50,9 @@ class Message extends Surface
     /**
      * Configures message to send to the entire channel.
      *
+     * @return static
      */
-    public function inChannel(): static
+    public function inChannel()
     {
         return $this->directives(self::IN_CHANNEL);
     }
@@ -58,8 +60,9 @@ class Message extends Surface
     /**
      * Configures message to "replace_original" mode.
      *
+     * @return static
      */
-    public function replaceOriginal(): static
+    public function replaceOriginal()
     {
         return $this->directives(self::REPLACE_ORIGINAL);
     }
@@ -67,16 +70,18 @@ class Message extends Surface
     /**
      * Configures message to "delete_original" mode.
      *
+     * @return static
      */
-    public function deleteOriginal(): static
+    public function deleteOriginal()
     {
         return $this->directives(self::DELETE_ORIGINAL);
     }
 
     /**
      * @param array $directives
+     * @return static
      */
-    private function directives(array $directives): static
+    private function directives(array $directives)
     {
         $this->directives = $directives;
 
@@ -88,8 +93,9 @@ class Message extends Surface
      *
      * @param string $message
      * @param bool|null $mrkdwn
+     * @return static
      */
-    public function fallbackText(string $message, ?bool $mrkdwn = null): static
+    public function fallbackText(string $message, ?bool $mrkdwn = null)
     {
         $this->fallbackText = ['text' => $message];
         if ($mrkdwn !== null) {
@@ -101,8 +107,9 @@ class Message extends Surface
 
     /**
      * @param Attachment $attachment
+     * @return static
      */
-    public function addAttachment(Attachment $attachment): static
+    public function addAttachment(Attachment $attachment)
     {
         $this->attachments[] = $attachment->setParent($this);
 
@@ -124,8 +131,9 @@ class Message extends Surface
      * Clones a message for the purpose of generating a Block Kit Builder preview URL.
      *
      * @internal Used by Previewer only.
+     * @return static
      */
-    public function asPreviewableMessage(): static
+    public function asPreviewableMessage()
     {
         $message = clone $this;
         $message->directives = [];

--- a/src/Surfaces/Message.php
+++ b/src/Surfaces/Message.php
@@ -40,9 +40,8 @@ class Message extends Surface
      *
      * This is default behavior for most interactions, and doesn't necessarily need to be explicitly configured.
      *
-     * @return static
      */
-    public function ephemeral(): self
+    public function ephemeral(): static
     {
         return $this->directives(self::EPHEMERAL);
     }
@@ -50,9 +49,8 @@ class Message extends Surface
     /**
      * Configures message to send to the entire channel.
      *
-     * @return static
      */
-    public function inChannel(): self
+    public function inChannel(): static
     {
         return $this->directives(self::IN_CHANNEL);
     }
@@ -60,9 +58,8 @@ class Message extends Surface
     /**
      * Configures message to "replace_original" mode.
      *
-     * @return static
      */
-    public function replaceOriginal(): self
+    public function replaceOriginal(): static
     {
         return $this->directives(self::REPLACE_ORIGINAL);
     }
@@ -70,18 +67,16 @@ class Message extends Surface
     /**
      * Configures message to "delete_original" mode.
      *
-     * @return static
      */
-    public function deleteOriginal(): self
+    public function deleteOriginal(): static
     {
         return $this->directives(self::DELETE_ORIGINAL);
     }
 
     /**
      * @param array $directives
-     * @return static
      */
-    private function directives(array $directives): self
+    private function directives(array $directives): static
     {
         $this->directives = $directives;
 
@@ -93,9 +88,8 @@ class Message extends Surface
      *
      * @param string $message
      * @param bool|null $mrkdwn
-     * @return Message
      */
-    public function fallbackText(string $message, ?bool $mrkdwn = null): self
+    public function fallbackText(string $message, ?bool $mrkdwn = null): static
     {
         $this->fallbackText = ['text' => $message];
         if ($mrkdwn !== null) {
@@ -107,9 +101,8 @@ class Message extends Surface
 
     /**
      * @param Attachment $attachment
-     * @return static
      */
-    public function addAttachment(Attachment $attachment): self
+    public function addAttachment(Attachment $attachment): static
     {
         $this->attachments[] = $attachment->setParent($this);
 
@@ -130,10 +123,9 @@ class Message extends Surface
     /**
      * Clones a message for the purpose of generating a Block Kit Builder preview URL.
      *
-     * @return Message
      * @internal Used by Previewer only.
      */
-    public function asPreviewableMessage(): self
+    public function asPreviewableMessage(): static
     {
         $message = clone $this;
         $message->directives = [];

--- a/src/Surfaces/Modal.php
+++ b/src/Surfaces/Modal.php
@@ -36,50 +36,50 @@ class Modal extends View
     /** @var bool */
     private $notifyOnClose;
 
-    public function setTitle(PlainText $title): self
+    public function setTitle(PlainText $title): static
     {
         $this->title = $title->setParent($this);
 
         return $this;
     }
 
-    public function setSubmit(PlainText $title): self
+    public function setSubmit(PlainText $title): static
     {
         $this->submit = $title->setParent($this);
 
         return $this;
     }
 
-    public function setClose(PlainText $title): self
+    public function setClose(PlainText $title): static
     {
         $this->close = $title->setParent($this);
 
         return $this;
     }
 
-    public function title(string $title): self
+    public function title(string $title): static
     {
         return $this->setTitle(new PlainText($title));
     }
 
-    public function submit(string $submit): self
+    public function submit(string $submit): static
     {
         return $this->setSubmit(new PlainText($submit));
     }
 
-    public function close(string $close): self
+    public function close(string $close): static
     {
         return $this->setClose(new PlainText($close));
     }
 
-    public function clearOnClose(bool $clearOnClose): self
+    public function clearOnClose(bool $clearOnClose): static
     {
         $this->clearOnClose = $clearOnClose;
 
         return $this;
     }
 
-    public function notifyOnClose(bool $notifyOnClose): self
+    public function notifyOnClose(bool $notifyOnClose): static
     {
         $this->notifyOnClose = $notifyOnClose;
 

--- a/src/Surfaces/Modal.php
+++ b/src/Surfaces/Modal.php
@@ -36,50 +36,74 @@ class Modal extends View
     /** @var bool */
     private $notifyOnClose;
 
-    public function setTitle(PlainText $title): static
+    /**
+    * @return static
+    */
+    public function setTitle(PlainText $title)
     {
         $this->title = $title->setParent($this);
 
         return $this;
     }
 
-    public function setSubmit(PlainText $title): static
+    /**
+    * @return static
+    */
+    public function setSubmit(PlainText $title)
     {
         $this->submit = $title->setParent($this);
 
         return $this;
     }
 
-    public function setClose(PlainText $title): static
+    /**
+    * @return static
+    */
+    public function setClose(PlainText $title)
     {
         $this->close = $title->setParent($this);
 
         return $this;
     }
 
-    public function title(string $title): static
+    /**
+    * @return static
+    */
+    public function title(string $title)
     {
         return $this->setTitle(new PlainText($title));
     }
 
-    public function submit(string $submit): static
+    /**
+    * @return static
+    */
+    public function submit(string $submit)
     {
         return $this->setSubmit(new PlainText($submit));
     }
 
-    public function close(string $close): static
+    /**
+    * @return static
+    */
+    public function close(string $close)
     {
         return $this->setClose(new PlainText($close));
     }
 
-    public function clearOnClose(bool $clearOnClose): static
+    /**
+    * @return static
+    */
+    public function clearOnClose(bool $clearOnClose)
     {
         $this->clearOnClose = $clearOnClose;
 
         return $this;
     }
 
-    public function notifyOnClose(bool $notifyOnClose): static
+    /**
+    * @return static
+    */
+    public function notifyOnClose(bool $notifyOnClose)
     {
         $this->notifyOnClose = $notifyOnClose;
 

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -25,9 +25,8 @@ abstract class Surface extends Element
 
     /**
      * @param BlockElement $block
-     * @return static
      */
-    public function add(BlockElement $block): self
+    public function add(BlockElement $block): static
     {
         if (!in_array($block->getType(), Type::SURFACE_BLOCKS[$this->getType()], true)) {
             throw new Exception(
@@ -43,9 +42,8 @@ abstract class Surface extends Element
 
     /**
      * @param iterable|BlockElement[] $blocks
-     * @return static
      */
-    public function blocks(iterable $blocks): self
+    public function blocks(iterable $blocks): static
     {
         foreach ($blocks as $block) {
             $this->add($block);
@@ -155,9 +153,8 @@ abstract class Surface extends Element
 
     /**
      * @param string|null $blockId
-     * @return static
      */
-    public function divider(?string $blockId = null): self
+    public function divider(?string $blockId = null): static
     {
         return $this->add(new Divider($blockId));
     }
@@ -165,9 +162,8 @@ abstract class Surface extends Element
     /**
      * @param string $text
      * @param string|null $blockId
-     * @return static
      */
-    public function text(string $text, ?string $blockId = null): self
+    public function text(string $text, ?string $blockId = null): static
     {
         $block = new Section($blockId, $text);
 
@@ -177,9 +173,8 @@ abstract class Surface extends Element
     /**
      * @param string $text
      * @param string|null $blockId
-     * @return static
      */
-    public function header(string $text, ?string $blockId = null): self
+    public function header(string $text, ?string $blockId = null): static
     {
         $block = new Header($blockId, $text);
 

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -25,8 +25,9 @@ abstract class Surface extends Element
 
     /**
      * @param BlockElement $block
+     * @return static
      */
-    public function add(BlockElement $block): static
+    public function add(BlockElement $block)
     {
         if (!in_array($block->getType(), Type::SURFACE_BLOCKS[$this->getType()], true)) {
             throw new Exception(
@@ -42,8 +43,9 @@ abstract class Surface extends Element
 
     /**
      * @param iterable|BlockElement[] $blocks
+     * @return static
      */
-    public function blocks(iterable $blocks): static
+    public function blocks(iterable $blocks)
     {
         foreach ($blocks as $block) {
             $this->add($block);
@@ -153,8 +155,9 @@ abstract class Surface extends Element
 
     /**
      * @param string|null $blockId
+     * @return static
      */
-    public function divider(?string $blockId = null): static
+    public function divider(?string $blockId = null)
     {
         return $this->add(new Divider($blockId));
     }
@@ -162,8 +165,9 @@ abstract class Surface extends Element
     /**
      * @param string $text
      * @param string|null $blockId
+     * @return static
      */
-    public function text(string $text, ?string $blockId = null): static
+    public function text(string $text, ?string $blockId = null)
     {
         $block = new Section($blockId, $text);
 
@@ -173,8 +177,9 @@ abstract class Surface extends Element
     /**
      * @param string $text
      * @param string|null $blockId
+     * @return static
      */
-    public function header(string $text, ?string $blockId = null): static
+    public function header(string $text, ?string $blockId = null)
     {
         $block = new Header($blockId, $text);
 

--- a/src/Surfaces/View.php
+++ b/src/Surfaces/View.php
@@ -27,8 +27,9 @@ abstract class View extends Surface
 
     /**
      * @param string $callbackId
+     * @return static
      */
-    public function callbackId(string $callbackId): static
+    public function callbackId(string $callbackId)
     {
         $this->callbackId = $callbackId;
 
@@ -37,8 +38,9 @@ abstract class View extends Surface
 
     /**
      * @param string $externalId
+     * @return static
      */
-    public function externalId(string $externalId): static
+    public function externalId(string $externalId)
     {
         $this->externalId = $externalId;
 
@@ -47,8 +49,9 @@ abstract class View extends Surface
 
     /**
      * @param string $privateMetadata
+     * @return static
      */
-    public function privateMetadata(string $privateMetadata): static
+    public function privateMetadata(string $privateMetadata)
     {
         $this->privateMetadata = $privateMetadata;
 
@@ -61,8 +64,9 @@ abstract class View extends Surface
      * Note: Can be decoded using `base64_decode()` and `parse_str()`.
      *
      * @param array $data
+     * @return static
      */
-    public function encodePrivateMetadata(array $data): static
+    public function encodePrivateMetadata(array $data)
     {
         return $this->privateMetadata(base64_encode(http_build_query($data)));
     }

--- a/src/Surfaces/View.php
+++ b/src/Surfaces/View.php
@@ -27,9 +27,8 @@ abstract class View extends Surface
 
     /**
      * @param string $callbackId
-     * @return static
      */
-    public function callbackId(string $callbackId): self
+    public function callbackId(string $callbackId): static
     {
         $this->callbackId = $callbackId;
 
@@ -38,9 +37,8 @@ abstract class View extends Surface
 
     /**
      * @param string $externalId
-     * @return static
      */
-    public function externalId(string $externalId): self
+    public function externalId(string $externalId): static
     {
         $this->externalId = $externalId;
 
@@ -49,9 +47,8 @@ abstract class View extends Surface
 
     /**
      * @param string $privateMetadata
-     * @return static
      */
-    public function privateMetadata(string $privateMetadata): self
+    public function privateMetadata(string $privateMetadata): static
     {
         $this->privateMetadata = $privateMetadata;
 
@@ -64,9 +61,8 @@ abstract class View extends Surface
      * Note: Can be decoded using `base64_decode()` and `parse_str()`.
      *
      * @param array $data
-     * @return static
      */
-    public function encodePrivateMetadata(array $data): self
+    public function encodePrivateMetadata(array $data): static
     {
         return $this->privateMetadata(base64_encode(http_build_query($data)));
     }

--- a/src/Surfaces/WorkflowStep.php
+++ b/src/Surfaces/WorkflowStep.php
@@ -21,14 +21,14 @@ class WorkflowStep extends Surface
     /** @var string */
     private $callbackId;
 
-    public function callbackId(string $callbackId): self
+    public function callbackId(string $callbackId): static
     {
         $this->callbackId = $callbackId;
 
         return $this;
     }
 
-    public function privateMetadata(string $privateMetadata): self
+    public function privateMetadata(string $privateMetadata): static
     {
         $this->privateMetadata = $privateMetadata;
 

--- a/src/Surfaces/WorkflowStep.php
+++ b/src/Surfaces/WorkflowStep.php
@@ -21,14 +21,20 @@ class WorkflowStep extends Surface
     /** @var string */
     private $callbackId;
 
-    public function callbackId(string $callbackId): static
+    /**
+    * @return static
+    */
+    public function callbackId(string $callbackId)
     {
         $this->callbackId = $callbackId;
 
         return $this;
     }
 
-    public function privateMetadata(string $privateMetadata): static
+    /**
+    * @return static
+    */
+    public function privateMetadata(string $privateMetadata)
     {
         $this->privateMetadata = $privateMetadata;
 


### PR DESCRIPTION
* `$this` を返すメソッドの戻り値のタイプヒントが `self` になってたり，そのクラス自体 (`: Modal {}`) とかになっててバラバラだったので `static` に統一

## 参考
https://github.com/lunain84/slack-php-block-kit/issues/3