### PR TITLE
fix jsonSerialize() signature

### DIFF
--- a/src/Element.php
+++ b/src/Element.php
@@ -137,10 +137,7 @@ abstract class Element implements JsonSerializable
         return (string) json_encode($this, $opts);
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return $this->toArray();
     }


### PR DESCRIPTION
php 8.1だと Element::jsonSerialize() が jsonSerialize(): mixed を正しく継承していない！（function() は function(): mixed を継承しないと言われる）と怒られてしまうので、PHPDocを実装部分に移動する