### PR TITLE
fix composer install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In general, we refer to all of the different things in Block Kit collectively as
 Install easily via Composer:
 
 ```bash
-composer require slack-php/slack-block-kit
+composer require fuwasegu/slack-php-block-kit-next
 ```
 
 Then include the Composer-generated autoloader in your project's initialization code.


### PR DESCRIPTION
the composer install  should be "composer require fuwasegu/slack-php-block-kit-next". I accidently installed the one from the foked repo and I was kind of autopilot and didn't even notice the command was actually installing the forked version