### PR TITLE
RichTextを生成できるように（RichTextInputのinitial_valueにも使えるように）

### DIFF
--- a/src/Blocks/RichText.php
+++ b/src/Blocks/RichText.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Blocks;
+
+use SlackPhp\BlockKit\{Element, Exception, HydrationData, Type};
+use SlackPhp\BlockKit\Partials\RichTextElements\{RichTextElement, RichTextSection, RichTextList, RichTextPreformatted, RichTextQuote};
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\{Text, TextElement};
+
+class RichText extends BlockElement
+{
+    /**
+     * @var RichTextElement[]
+     */
+    private array $elements = [];
+
+    public function __construct(?string $blockId = null)
+    {
+        parent::__construct($blockId);
+    }
+
+    /**
+     * 要素を追加する
+     */
+    public function addElement(RichTextElement $element): static
+    {
+        $this->elements[] = $element->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを設定する
+     *
+     * @param RichTextElement[] $elements
+     */
+    public function setElements(array $elements): static
+    {
+        $this->elements = [];
+
+        foreach ($elements as $element) {
+            $this->addElement($element);
+        }
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを取得する
+     *
+     * @return RichTextElement[]
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * 新しいセクションを作成して追加する
+     */
+    public function newSection(): RichTextSection
+    {
+        $section = new RichTextSection();
+        $this->addElement($section);
+
+        return $section;
+    }
+
+    /**
+     * テキストを含む新しいセクションを作成して追加する
+     */
+    public function addText(string $text, ?array $style = null): static
+    {
+        $section = $this->newSection();
+        $textElement = new Text();
+        $textElement->text($text);
+
+        if ($style !== null) {
+            $textElement->setStyle($style);
+        }
+
+        $section->addElement($textElement);
+
+        return $this;
+    }
+
+    /**
+     * 太字テキストを含む新しいセクションを作成して追加する
+     */
+    public function addBoldText(string $text): static
+    {
+        return $this->addText($text, ['bold' => true]);
+    }
+
+    /**
+     * 斜体テキストを含む新しいセクションを作成して追加する
+     */
+    public function addItalicText(string $text): static
+    {
+        return $this->addText($text, ['italic' => true]);
+    }
+
+    /**
+     * 取り消し線テキストを含む新しいセクションを作成して追加する
+     */
+    public function addStrikeText(string $text): static
+    {
+        return $this->addText($text, ['strike' => true]);
+    }
+
+    /**
+     * 新しいリストを作成して追加する
+     */
+    public function newList(string $style = 'bullet'): RichTextList
+    {
+        $list = new RichTextList();
+        $list->setStyle($style);
+        $this->addElement($list);
+
+        return $list;
+    }
+
+    /**
+     * 新しい箇条書きリストを作成して追加する
+     */
+    public function newBulletList(): RichTextList
+    {
+        return $this->newList('bullet');
+    }
+
+    /**
+     * 新しい番号付きリストを作成して追加する
+     */
+    public function newOrderedList(): RichTextList
+    {
+        return $this->newList('ordered');
+    }
+
+    /**
+     * 新しいコードブロックを作成して追加する
+     */
+    public function addCode(string $code): static
+    {
+        $preformatted = new RichTextPreformatted();
+        $preformatted->text($code);
+        $this->addElement($preformatted);
+
+        return $this;
+    }
+
+    /**
+     * 新しい引用ブロックを作成して追加する
+     */
+    public function newQuote(): RichTextQuote
+    {
+        $quote = new RichTextQuote();
+        $this->addElement($quote);
+
+        return $quote;
+    }
+
+    /**
+     * テキストを含む新しい引用ブロックを作成して追加する
+     */
+    public function addQuote(string $text): static
+    {
+        $quote = $this->newQuote();
+        $textElement = new Text();
+        $textElement->text($text);
+        $quote->addElement($textElement);
+
+        return $this;
+    }
+
+    /**
+     * ブロックを検証する
+     */
+    public function validate(): void
+    {
+        if ($this->elements === []) {
+            throw new Exception('RichText block must have at least one element');
+        }
+
+        foreach ($this->elements as $element) {
+            $element->validate();
+        }
+    }
+
+    /**
+     * ブロックを配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['type'] = Type::RICH_TEXT;
+
+        $elements = [];
+        foreach ($this->elements as $element) {
+            $elements[] = $element->toArray();
+        }
+
+        $data['elements'] = $elements;
+
+        return $data;
+    }
+
+    /**
+     * 配列からブロックを生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('elements')) {
+            $elements = $data->useArray('elements');
+            foreach ($elements as $element) {
+                if (!isset($element['type'])) {
+                    throw new Exception('RichText element data must include a type');
+                }
+
+                $type = $element['type'];
+                $richTextElement = RichTextElement::createFromType($type);
+                $richTextElement->hydrate(new HydrationData($element));
+                $this->addElement($richTextElement);
+            }
+        }
+    }
+}

--- a/src/Blocks/RichText.php
+++ b/src/Blocks/RichText.php
@@ -21,7 +21,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 要素を追加する
+     * Add an element
      */
     public function addElement(RichTextElement $element): static
     {
@@ -31,7 +31,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 要素のコレクションを設定する
+     * Set a collection of elements
      *
      * @param RichTextElement[] $elements
      */
@@ -47,7 +47,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 要素のコレクションを取得する
+     * Get the collection of elements
      *
      * @return RichTextElement[]
      */
@@ -57,7 +57,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しいセクションを作成して追加する
+     * Create a new section and add it
      */
     public function newSection(): RichTextSection
     {
@@ -68,7 +68,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * テキストを含む新しいセクションを作成して追加する
+     * Create a new section with text and add it
      */
     public function addText(string $text, ?array $style = null): static
     {
@@ -86,7 +86,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 太字テキストを含む新しいセクションを作成して追加する
+     * Create a new section with bold text and add it
      */
     public function addBoldText(string $text): static
     {
@@ -94,7 +94,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 斜体テキストを含む新しいセクションを作成して追加する
+     * Create a new section with italic text and add it
      */
     public function addItalicText(string $text): static
     {
@@ -102,7 +102,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 取り消し線テキストを含む新しいセクションを作成して追加する
+     * Create a new section with strikethrough text and add it
      */
     public function addStrikeText(string $text): static
     {
@@ -110,12 +110,12 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しいリストを作成して追加する
+     * Create a new list and add it
      *
-     * @param string   $style  リストのスタイル ('bullet' または 'ordered')
-     * @param int|null $indent インデントのピクセル数
-     * @param int|null $offset オフセットのピクセル数
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param string   $style  List style ('bullet' or 'ordered')
+     * @param int|null $indent Indent in pixels
+     * @param int|null $offset Offset in pixels
+     * @param int|null $border Border width in pixels
      */
     public function newList(string $style = 'bullet', ?int $indent = null, ?int $offset = null, ?int $border = null): RichTextList
     {
@@ -140,11 +140,11 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しい箇条書きリストを作成して追加する
+     * Create a new bullet list and add it
      *
-     * @param int|null $indent インデントのピクセル数
-     * @param int|null $offset オフセットのピクセル数
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param int|null $indent Indent in pixels
+     * @param int|null $offset Offset in pixels
+     * @param int|null $border Border width in pixels
      */
     public function newBulletList(?int $indent = null, ?int $offset = null, ?int $border = null): RichTextList
     {
@@ -152,11 +152,11 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しい番号付きリストを作成して追加する
+     * Create a new ordered list and add it
      *
-     * @param int|null $indent インデントのピクセル数
-     * @param int|null $offset オフセットのピクセル数
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param int|null $indent Indent in pixels
+     * @param int|null $offset Offset in pixels
+     * @param int|null $border Border width in pixels
      */
     public function newOrderedList(?int $indent = null, ?int $offset = null, ?int $border = null): RichTextList
     {
@@ -164,10 +164,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しいコードブロックを作成して追加する
+     * Add a code block with the given code text
      *
-     * @param string   $code   コードテキスト
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param string   $code   Code text
+     * @param int|null $border Border width in pixels
      */
     public function addCode(string $code, ?int $border = null): static
     {
@@ -178,9 +178,9 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しいプリフォーマットブロックを作成して追加する
+     * Create a new preformatted block and add it
      *
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param int|null $border Border width in pixels
      */
     public function newPreformatted(?int $border = null): RichTextPreformatted
     {
@@ -196,9 +196,9 @@ class RichText extends BlockElement
     }
 
     /**
-     * 新しい引用ブロックを作成して追加する
+     * Create a new quote block and add it
      *
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param int|null $border Border width in pixels
      */
     public function newQuote(?int $border = null): RichTextQuote
     {
@@ -214,10 +214,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * 引用テキストを含む新しい引用ブロックを作成して追加する
+     * Create a new quote block with text and add it
      *
-     * @param string   $text   引用テキスト
-     * @param int|null $border ボーダーの太さ（ピクセル単位）
+     * @param string   $text   Quote text
+     * @param int|null $border Border width in pixels
      */
     public function addQuote(string $text, ?int $border = null): static
     {
@@ -230,11 +230,11 @@ class RichText extends BlockElement
     }
 
     /**
-     * リンク要素を含む新しいセクションを作成して追加する
+     * Create a new section with a link element and add it
      *
-     * @param string      $url   リンクのURL
-     * @param string|null $text  リンクのテキスト（省略時はURLが使用される）
-     * @param array|null  $style スタイル設定
+     * @param string      $url   Link URL
+     * @param string|null $text  Link text (URL is used if omitted)
+     * @param array|null  $style Style settings
      */
     public function addLink(string $url, ?string $text = null, ?array $style = null): static
     {
@@ -256,9 +256,9 @@ class RichText extends BlockElement
     }
 
     /**
-     * ブロードキャスト要素を含む新しいセクションを作成して追加する
+     * Add a broadcast element to the new section
      *
-     * @param string $range ブロードキャストの範囲 ('here', 'channel', 'everyone')
+     * @param string $range Broadcast range ('here', 'channel', 'everyone')
      */
     public function addBroadcast(string $range): static
     {
@@ -275,9 +275,9 @@ class RichText extends BlockElement
     }
 
     /**
-     * カラー要素を含む新しいセクションを作成して追加する
+     * Add a color element to the new section
      *
-     * @param string $hexColor 16進数のカラーコード
+     * @param string $hexColor 16-digit color code
      */
     public function addColor(string $hexColor): static
     {
@@ -290,10 +290,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * チャンネル要素を含む新しいセクションを作成して追加する
+     * Add a channel element to the new section
      *
-     * @param string     $channelId チャンネルID
-     * @param array|null $style     スタイル設定 (bold, italic, strike, highlight, client_highlight, unlink)
+     * @param string     $channelId Channel ID
+     * @param array|null $style     Style settings (bold, italic, strike, highlight, client_highlight, unlink)
      */
     public function addChannel(string $channelId, ?array $style = null): static
     {
@@ -311,12 +311,12 @@ class RichText extends BlockElement
     }
 
     /**
-     * 日付要素を含む新しいセクションを作成して追加する
+     * Add a date element to the new section
      *
-     * @param int         $timestamp Unix タイムスタンプ（秒単位）
-     * @param string      $format    日付フォーマット
-     * @param string|null $url       リンクURL
-     * @param string|null $fallback  フォールバックテキスト
+     * @param int         $timestamp Unix timestamp (in seconds)
+     * @param string      $format    Date format
+     * @param string|null $url       Link URL
+     * @param string|null $fallback  Fallback text
      */
     public function addDate(int $timestamp, string $format, ?string $url = null, ?string $fallback = null): static
     {
@@ -338,10 +338,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * 絵文字要素を含む新しいセクションを作成して追加する
+     * Add an emoji element to the new section
      *
-     * @param string      $name    絵文字名
-     * @param string|null $unicode Unicode コードポイント
+     * @param string      $name    Emoji name
+     * @param string|null $unicode Unicode code point
      */
     public function addEmoji(string $name, ?string $unicode = null): static
     {
@@ -359,10 +359,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * ユーザー要素を含む新しいセクションを作成して追加する
+     * Add a user element to the new section
      *
-     * @param string     $userId ユーザーID
-     * @param array|null $style  スタイル設定 (bold, italic, strike, highlight, client_highlight, unlink)
+     * @param string     $userId User ID
+     * @param array|null $style  Style settings (bold, italic, strike, highlight, client_highlight, unlink)
      */
     public function addUser(string $userId, ?array $style = null): static
     {
@@ -380,10 +380,10 @@ class RichText extends BlockElement
     }
 
     /**
-     * ユーザーグループ要素を含む新しいセクションを作成して追加する
+     * Add a user group element to the new section
      *
-     * @param string     $usergroupId ユーザーグループID
-     * @param array|null $style       スタイル設定 (bold, italic, strike, highlight, client_highlight, unlink)
+     * @param string     $usergroupId User group ID
+     * @param array|null $style       Style settings (bold, italic, strike, highlight, client_highlight, unlink)
      */
     public function addUserGroup(string $usergroupId, ?array $style = null): static
     {
@@ -401,11 +401,11 @@ class RichText extends BlockElement
     }
 
     /**
-     * ブロックを検証する
+     * Validate the block
      */
     public function validate(): void
     {
-        // elements は空配列も許可する（仕様に基づく修正）
+        // Empty elements array is allowed (according to the specification)
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -413,7 +413,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * ブロックを配列に変換する
+     * Convert the block to an array
      */
     public function toArray(): array
     {
@@ -431,7 +431,7 @@ class RichText extends BlockElement
     }
 
     /**
-     * 配列からブロックを生成する
+     * Hydrate the block from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Element.php
+++ b/src/Element.php
@@ -145,6 +145,7 @@ abstract class Element implements JsonSerializable
         /** @var static $element */
         $element = new $class();
         $element->hydrate($data);
+        $element->validate();
 
         return $element;
     }
@@ -164,7 +165,5 @@ abstract class Element implements JsonSerializable
         foreach ($data->getExtra() as $key => $value) {
             $this->setExtra($key, $value);
         }
-
-        $this->validate();
     }
 }

--- a/src/Inputs/RichTextInput.php
+++ b/src/Inputs/RichTextInput.php
@@ -14,7 +14,7 @@ class RichTextInput extends InputElement
     use HasPlaceholder;
 
     /**
-     * RichTextInputの設定オプション
+     * Configuration options for RichTextInput
      */
     private ?bool $focusOnLoad = null;
 
@@ -23,9 +23,9 @@ class RichTextInput extends InputElement
     private ?RichText $initialValue = null;
 
     /**
-     * リッチテキスト入力の初期値を設定する
+     * Set the initial value for rich text input
      *
-     * @param RichText $richText リッチテキストブロック
+     * @param RichText $richText Rich text block
      */
     public function initialValue(RichText $richText): static
     {

--- a/src/Kit.php
+++ b/src/Kit.php
@@ -34,6 +34,11 @@ abstract class Kit
         return new Surfaces\Modal();
     }
 
+    public static function newRichText(?string $blockId = null): Blocks\RichText
+    {
+        return new Blocks\RichText($blockId);
+    }
+
     public static function config(): Config
     {
         if (!self::$config instanceof Config) {

--- a/src/Partials/RichTextElements/RichTextElement.php
+++ b/src/Partials/RichTextElements/RichTextElement.php
@@ -28,9 +28,10 @@ abstract class RichTextElement extends Element
      * 型から対応するRichTextElement要素を作成する
      *
      * @param  string    $type 要素の型
+     * @return static    作成された要素
      * @throws Exception
      */
-    public static function createFromType(string $type): self
+    public static function createFromType(string $type): static
     {
         $class = self::getClassForType($type);
 
@@ -38,7 +39,7 @@ abstract class RichTextElement extends Element
             throw new Exception('Unknown rich text element type: %s', [$type]);
         }
 
-        /** @var RichTextElement $element */
+        // @phpstan-ignore-next-line
         return new $class();
     }
 

--- a/src/Partials/RichTextElements/RichTextElement.php
+++ b/src/Partials/RichTextElements/RichTextElement.php
@@ -9,12 +9,12 @@ use SlackPhp\BlockKit\{Element, Exception, HydrationData};
 abstract class RichTextElement extends Element
 {
     /**
-     * 要素の型を取得する
+     * Get the element type
      */
     abstract public function getElementType(): string;
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -25,10 +25,10 @@ abstract class RichTextElement extends Element
     }
 
     /**
-     * 型から対応するRichTextElement要素を作成する
+     * Create a RichTextElement from the specified type
      *
-     * @param  string    $type 要素の型
-     * @return static    作成された要素
+     * @param  string    $type Element type
+     * @return static    Created element
      * @throws Exception
      */
     public static function createFromType(string $type): static
@@ -44,10 +44,10 @@ abstract class RichTextElement extends Element
     }
 
     /**
-     * 型に対応するクラス名を取得する
+     * Get the class name corresponding to the type
      *
-     * @param  string $type 要素の型
-     * @return string クラス名
+     * @param  string $type Element type
+     * @return string Class name
      */
     protected static function getClassForType(string $type): string
     {

--- a/src/Partials/RichTextElements/RichTextElement.php
+++ b/src/Partials/RichTextElements/RichTextElement.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\{Element, Exception, HydrationData};
+
+abstract class RichTextElement extends Element
+{
+    /**
+     * 要素の型を取得する
+     */
+    abstract public function getElementType(): string;
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['type'] = $this->getElementType();
+
+        return $data;
+    }
+
+    /**
+     * 型から対応するRichTextElement要素を作成する
+     *
+     * @param  string    $type 要素の型
+     * @throws Exception
+     */
+    public static function createFromType(string $type): self
+    {
+        $class = self::getClassForType($type);
+
+        if (!class_exists($class)) {
+            throw new Exception('Unknown rich text element type: %s', [$type]);
+        }
+
+        /** @var RichTextElement $element */
+        return new $class();
+    }
+
+    /**
+     * 型に対応するクラス名を取得する
+     *
+     * @param  string $type 要素の型
+     * @return string クラス名
+     */
+    protected static function getClassForType(string $type): string
+    {
+        $map = [
+            'rich_text_section' => RichTextSection::class,
+            'rich_text_list' => RichTextList::class,
+            'rich_text_preformatted' => RichTextPreformatted::class,
+            'rich_text_quote' => RichTextQuote::class,
+        ];
+
+        return $map[$type] ?? '';
+    }
+}

--- a/src/Partials/RichTextElements/RichTextList.php
+++ b/src/Partials/RichTextElements/RichTextList.php
@@ -17,6 +17,8 @@ class RichTextList extends RichTextElement
 
     private ?int $indent = null;
 
+    private ?int $offset = null;
+
     private ?int $border = null;
 
     /**
@@ -90,11 +92,17 @@ class RichTextList extends RichTextElement
      */
     public function setIndent(int $indent): static
     {
-        if ($indent < 0) {
-            throw new Exception('Indent must be a non-negative integer');
-        }
-
         $this->indent = $indent;
+
+        return $this;
+    }
+
+    /**
+     * オフセットを設定する
+     */
+    public function setOffset(int $offset): static
+    {
+        $this->offset = $offset;
 
         return $this;
     }
@@ -104,10 +112,6 @@ class RichTextList extends RichTextElement
      */
     public function setBorder(int $border): static
     {
-        if ($border < 0) {
-            throw new Exception('Border must be a non-negative integer');
-        }
-
         $this->border = $border;
 
         return $this;
@@ -130,9 +134,7 @@ class RichTextList extends RichTextElement
             throw new Exception('RichTextList must have a style');
         }
 
-        if ($this->elements === []) {
-            throw new Exception('RichTextList must have at least one element');
-        }
+        // elements は空配列も許可する（仕様に準拠）
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -158,6 +160,10 @@ class RichTextList extends RichTextElement
             $data['indent'] = $this->indent;
         }
 
+        if ($this->offset !== null) {
+            $data['offset'] = $this->offset;
+        }
+
         if ($this->border !== null) {
             $data['border'] = $this->border;
         }
@@ -174,10 +180,17 @@ class RichTextList extends RichTextElement
 
         if ($data->has('style')) {
             $this->setStyle($data->useValue('style'));
+        } else {
+            // style は必須属性なので、存在しない場合はエラーを投げる
+            throw new Exception('RichTextList must have a style');
         }
 
         if ($data->has('indent')) {
             $this->setIndent($data->useValue('indent'));
+        }
+
+        if ($data->has('offset')) {
+            $this->setOffset($data->useValue('offset'));
         }
 
         if ($data->has('border')) {

--- a/src/Partials/RichTextElements/RichTextList.php
+++ b/src/Partials/RichTextElements/RichTextList.php
@@ -22,7 +22,7 @@ class RichTextList extends RichTextElement
     private ?int $border = null;
 
     /**
-     * 要素を追加する
+     * Add an element
      */
     public function addElement(RichTextSection $element): static
     {
@@ -32,7 +32,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを設定する
+     * Set a collection of elements
      *
      * @param RichTextSection[] $elements
      */
@@ -48,8 +48,6 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを取得する
-     *
      * @return RichTextSection[]
      */
     public function getElements(): array
@@ -58,7 +56,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * リストスタイルを設定する
+     * Set the list style
      */
     public function setStyle(string $style): static
     {
@@ -72,7 +70,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 箇条書きスタイルを設定する
+     * Set bullet style
      */
     public function bullet(): static
     {
@@ -80,7 +78,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 番号付きスタイルを設定する
+     * Set ordered style
      */
     public function ordered(): static
     {
@@ -88,7 +86,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * インデントレベルを設定する
+     * Set the indent level
      */
     public function setIndent(int $indent): static
     {
@@ -98,7 +96,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * オフセットを設定する
+     * Set the offset
      */
     public function setOffset(int $offset): static
     {
@@ -108,7 +106,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * ボーダーを設定する
+     * Set the border
      */
     public function setBorder(int $border): static
     {
@@ -117,16 +115,13 @@ class RichTextList extends RichTextElement
         return $this;
     }
 
-    /**
-     * 要素の型を取得する
-     */
     public function getElementType(): string
     {
         return 'rich_text_list';
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -134,7 +129,7 @@ class RichTextList extends RichTextElement
             throw new Exception('RichTextList must have a style');
         }
 
-        // elements は空配列も許可する（仕様に準拠）
+        // Empty elements array is allowed (according to the specification)
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -142,7 +137,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -172,7 +167,7 @@ class RichTextList extends RichTextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {
@@ -181,7 +176,7 @@ class RichTextList extends RichTextElement
         if ($data->has('style')) {
             $this->setStyle($data->useValue('style'));
         } else {
-            // style は必須属性なので、存在しない場合はエラーを投げる
+            // Style is a required attribute, so throw an error if it doesn't exist
             throw new Exception('RichTextList must have a style');
         }
 

--- a/src/Partials/RichTextElements/RichTextList.php
+++ b/src/Partials/RichTextElements/RichTextList.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class RichTextList extends RichTextElement
+{
+    /**
+     * @var RichTextSection[]
+     */
+    private array $elements = [];
+
+    private ?string $style = null;
+
+    private ?int $indent = null;
+
+    private ?int $border = null;
+
+    /**
+     * 要素を追加する
+     */
+    public function addElement(RichTextSection $element): static
+    {
+        $this->elements[] = $element->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを設定する
+     *
+     * @param RichTextSection[] $elements
+     */
+    public function setElements(array $elements): static
+    {
+        $this->elements = [];
+
+        foreach ($elements as $element) {
+            $this->addElement($element);
+        }
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを取得する
+     *
+     * @return RichTextSection[]
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * リストスタイルを設定する
+     */
+    public function setStyle(string $style): static
+    {
+        if (!in_array($style, ['bullet', 'ordered'], true)) {
+            throw new Exception('Invalid list style: %s', [$style]);
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 箇条書きスタイルを設定する
+     */
+    public function bullet(): static
+    {
+        return $this->setStyle('bullet');
+    }
+
+    /**
+     * 番号付きスタイルを設定する
+     */
+    public function ordered(): static
+    {
+        return $this->setStyle('ordered');
+    }
+
+    /**
+     * インデントレベルを設定する
+     */
+    public function setIndent(int $indent): static
+    {
+        if ($indent < 0) {
+            throw new Exception('Indent must be a non-negative integer');
+        }
+
+        $this->indent = $indent;
+
+        return $this;
+    }
+
+    /**
+     * ボーダーを設定する
+     */
+    public function setBorder(int $border): static
+    {
+        if ($border < 0) {
+            throw new Exception('Border must be a non-negative integer');
+        }
+
+        $this->border = $border;
+
+        return $this;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'rich_text_list';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->style === null) {
+            throw new Exception('RichTextList must have a style');
+        }
+
+        if ($this->elements === []) {
+            throw new Exception('RichTextList must have at least one element');
+        }
+
+        foreach ($this->elements as $element) {
+            $element->validate();
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        $elements = [];
+        foreach ($this->elements as $element) {
+            $elements[] = $element->toArray();
+        }
+
+        $data['elements'] = $elements;
+        $data['style'] = $this->style;
+
+        if ($this->indent !== null) {
+            $data['indent'] = $this->indent;
+        }
+
+        if ($this->border !== null) {
+            $data['border'] = $this->border;
+        }
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useValue('style'));
+        }
+
+        if ($data->has('indent')) {
+            $this->setIndent($data->useValue('indent'));
+        }
+
+        if ($data->has('border')) {
+            $this->setBorder($data->useValue('border'));
+        }
+
+        if ($data->has('elements')) {
+            $elements = $data->useArray('elements');
+            foreach ($elements as $element) {
+                if (!isset($element['type'])) {
+                    throw new Exception('RichTextList element data must include a type');
+                }
+
+                if ($element['type'] !== 'rich_text_section') {
+                    throw new Exception('RichTextList elements must be of type rich_text_section');
+                }
+
+                $section = new RichTextSection();
+                $section->hydrate(new HydrationData($element));
+                $this->addElement($section);
+            }
+        }
+    }
+}

--- a/src/Partials/RichTextElements/RichTextPreformatted.php
+++ b/src/Partials/RichTextElements/RichTextPreformatted.php
@@ -17,7 +17,7 @@ class RichTextPreformatted extends RichTextElement
     private ?int $border = null;
 
     /**
-     * 要素を追加する
+     * Add an element
      */
     public function addElement(TextElement $element): static
     {
@@ -27,7 +27,7 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを設定する
+     * Set a collection of elements
      *
      * @param TextElement[] $elements
      */
@@ -43,8 +43,6 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを取得する
-     *
      * @return TextElement[]
      */
     public function getElements(): array
@@ -53,7 +51,7 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * テキストを設定する（後方互換性のため）
+     * Set text (for backward compatibility)
      */
     public function text(string $text): static
     {
@@ -65,7 +63,7 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * ボーダーを設定する
+     * Set the border
      */
     public function setBorder(int $border): static
     {
@@ -74,20 +72,17 @@ class RichTextPreformatted extends RichTextElement
         return $this;
     }
 
-    /**
-     * 要素の型を取得する
-     */
     public function getElementType(): string
     {
         return 'rich_text_preformatted';
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
-        // elements は空配列も許可する（仕様に準拠）
+        // Empty elements array is allowed (according to the specification)
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -95,7 +90,7 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -116,13 +111,13 @@ class RichTextPreformatted extends RichTextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {
         parent::hydrate($data);
 
-        // 後方互換性のためのサポート
+        // Support for backward compatibility
         if ($data->has('text')) {
             $this->text($data->useValue('text'));
         }

--- a/src/Partials/RichTextElements/RichTextPreformatted.php
+++ b/src/Partials/RichTextElements/RichTextPreformatted.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class RichTextPreformatted extends RichTextElement
+{
+    private ?string $text = null;
+
+    private ?string $border = null;
+
+    /**
+     * テキストを設定する
+     */
+    public function text(string $text): static
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * テキストを取得する
+     */
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    /**
+     * ボーダーを設定する
+     */
+    public function setBorder(string $border): static
+    {
+        $this->border = $border;
+
+        return $this;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'rich_text_preformatted';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->text === null || $this->text === '') {
+            throw new Exception('RichTextPreformatted must have a text value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['text'] = $this->text;
+
+        if ($this->border !== null) {
+            $data['border'] = $this->border;
+        }
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('text')) {
+            $this->text($data->useValue('text'));
+        }
+
+        if ($data->has('border')) {
+            $this->setBorder($data->useValue('border'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/RichTextQuote.php
+++ b/src/Partials/RichTextElements/RichTextQuote.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\{Element, Exception, HydrationData};
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\TextElement;
+
+class RichTextQuote extends RichTextElement
+{
+    /**
+     * @var TextElement[]
+     */
+    private array $elements = [];
+
+    private ?int $border = null;
+
+    /**
+     * 要素を追加する
+     */
+    public function addElement(TextElement $element): static
+    {
+        $this->elements[] = $element->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを設定する
+     *
+     * @param TextElement[] $elements
+     */
+    public function setElements(array $elements): static
+    {
+        $this->elements = [];
+
+        foreach ($elements as $element) {
+            $this->addElement($element);
+        }
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを取得する
+     *
+     * @return TextElement[]
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * ボーダーを設定する
+     */
+    public function setBorder(int $border): static
+    {
+        if ($border < 0) {
+            throw new Exception('Border must be a non-negative integer');
+        }
+
+        $this->border = $border;
+
+        return $this;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'rich_text_quote';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->elements === []) {
+            throw new Exception('RichTextQuote must have at least one element');
+        }
+
+        foreach ($this->elements as $element) {
+            $element->validate();
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        $elements = [];
+        foreach ($this->elements as $element) {
+            $elements[] = $element->toArray();
+        }
+
+        $data['elements'] = $elements;
+
+        if ($this->border !== null) {
+            $data['border'] = $this->border;
+        }
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('border')) {
+            $this->setBorder($data->useValue('border'));
+        }
+
+        if ($data->has('elements')) {
+            $elements = $data->useArray('elements');
+            foreach ($elements as $element) {
+                if (!isset($element['type'])) {
+                    throw new Exception('RichTextQuote element data must include a type');
+                }
+
+                $type = $element['type'];
+                $textElement = TextElement::createFromType($type);
+                $textElement->hydrate(new HydrationData($element));
+                $this->addElement($textElement);
+            }
+        }
+    }
+}

--- a/src/Partials/RichTextElements/RichTextQuote.php
+++ b/src/Partials/RichTextElements/RichTextQuote.php
@@ -17,7 +17,7 @@ class RichTextQuote extends RichTextElement
     private ?int $border = null;
 
     /**
-     * 要素を追加する
+     * Add an element
      */
     public function addElement(TextElement $element): static
     {
@@ -27,7 +27,7 @@ class RichTextQuote extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを設定する
+     * Set a collection of elements
      *
      * @param TextElement[] $elements
      */
@@ -43,8 +43,6 @@ class RichTextQuote extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを取得する
-     *
      * @return TextElement[]
      */
     public function getElements(): array
@@ -53,7 +51,7 @@ class RichTextQuote extends RichTextElement
     }
 
     /**
-     * ボーダーを設定する
+     * Set the border
      */
     public function setBorder(int $border): static
     {
@@ -62,20 +60,17 @@ class RichTextQuote extends RichTextElement
         return $this;
     }
 
-    /**
-     * 要素の型を取得する
-     */
     public function getElementType(): string
     {
         return 'rich_text_quote';
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
-        // elements は空配列も許可する（仕様に準拠）
+        // Empty elements array is allowed (according to the specification)
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -83,7 +78,7 @@ class RichTextQuote extends RichTextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -104,7 +99,7 @@ class RichTextQuote extends RichTextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/RichTextQuote.php
+++ b/src/Partials/RichTextElements/RichTextQuote.php
@@ -57,10 +57,6 @@ class RichTextQuote extends RichTextElement
      */
     public function setBorder(int $border): static
     {
-        if ($border < 0) {
-            throw new Exception('Border must be a non-negative integer');
-        }
-
         $this->border = $border;
 
         return $this;
@@ -79,9 +75,7 @@ class RichTextQuote extends RichTextElement
      */
     public function validate(): void
     {
-        if ($this->elements === []) {
-            throw new Exception('RichTextQuote must have at least one element');
-        }
+        // elements は空配列も許可する（仕様に準拠）
 
         foreach ($this->elements as $element) {
             $element->validate();

--- a/src/Partials/RichTextElements/RichTextSection.php
+++ b/src/Partials/RichTextElements/RichTextSection.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\{Element, Exception, HydrationData};
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\TextElement;
+
+class RichTextSection extends RichTextElement
+{
+    /**
+     * @var TextElement[]
+     */
+    private array $elements = [];
+
+    /**
+     * 要素を追加する
+     */
+    public function addElement(TextElement $element): static
+    {
+        $this->elements[] = $element->setParent($this);
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを設定する
+     *
+     * @param TextElement[] $elements
+     */
+    public function setElements(array $elements): static
+    {
+        $this->elements = [];
+
+        foreach ($elements as $element) {
+            $this->addElement($element);
+        }
+
+        return $this;
+    }
+
+    /**
+     * 要素のコレクションを取得する
+     *
+     * @return TextElement[]
+     */
+    public function getElements(): array
+    {
+        return $this->elements;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'rich_text_section';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->elements === []) {
+            throw new Exception('RichTextSection must have at least one element');
+        }
+
+        foreach ($this->elements as $element) {
+            $element->validate();
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+
+        $elements = [];
+        foreach ($this->elements as $element) {
+            $elements[] = $element->toArray();
+        }
+
+        $data['elements'] = $elements;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('elements')) {
+            $elements = $data->useArray('elements');
+            foreach ($elements as $element) {
+                if (!isset($element['type'])) {
+                    throw new Exception('RichTextSection element data must include a type');
+                }
+
+                $type = $element['type'];
+                $textElement = TextElement::createFromType($type);
+                $textElement->hydrate(new HydrationData($element));
+                $this->addElement($textElement);
+            }
+        }
+    }
+}

--- a/src/Partials/RichTextElements/RichTextSection.php
+++ b/src/Partials/RichTextElements/RichTextSection.php
@@ -15,7 +15,7 @@ class RichTextSection extends RichTextElement
     private array $elements = [];
 
     /**
-     * 要素を追加する
+     * Add an element
      */
     public function addElement(TextElement $element): static
     {
@@ -25,7 +25,7 @@ class RichTextSection extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを設定する
+     * Set a collection of elements
      *
      * @param TextElement[] $elements
      */
@@ -41,8 +41,6 @@ class RichTextSection extends RichTextElement
     }
 
     /**
-     * 要素のコレクションを取得する
-     *
      * @return TextElement[]
      */
     public function getElements(): array
@@ -50,20 +48,17 @@ class RichTextSection extends RichTextElement
         return $this->elements;
     }
 
-    /**
-     * 要素の型を取得する
-     */
     public function getElementType(): string
     {
         return 'rich_text_section';
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
-        // elements は空配列も許可する（Slack API仕様に準拠）
+        // Empty elements array is allowed (according to Slack API specification)
 
         foreach ($this->elements as $element) {
             $element->validate();
@@ -71,7 +66,7 @@ class RichTextSection extends RichTextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -88,7 +83,7 @@ class RichTextSection extends RichTextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/RichTextSection.php
+++ b/src/Partials/RichTextElements/RichTextSection.php
@@ -63,9 +63,7 @@ class RichTextSection extends RichTextElement
      */
     public function validate(): void
     {
-        if ($this->elements === []) {
-            throw new Exception('RichTextSection must have at least one element');
-        }
+        // elements は空配列も許可する（Slack API仕様に準拠）
 
         foreach ($this->elements as $element) {
             $element->validate();

--- a/src/Partials/RichTextElements/TextElements/Broadcast.php
+++ b/src/Partials/RichTextElements/TextElements/Broadcast.php
@@ -13,7 +13,7 @@ class Broadcast extends TextElement
     /**
      * 範囲を設定する
      */
-    public function range(string $range): static
+    public function setRange(string $range): static
     {
         if (!in_array($range, ['here', 'channel', 'everyone'], true)) {
             throw new Exception('Broadcast range must be one of: here, channel, everyone');
@@ -25,35 +25,27 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 範囲を取得する
-     */
-    public function getRange(): ?string
-    {
-        return $this->range;
-    }
-
-    /**
-     * @here ブロードキャストを設定する
+     * 'here'範囲を設定する
      */
     public function here(): static
     {
-        return $this->range('here');
+        return $this->setRange('here');
     }
 
     /**
-     * @channel ブロードキャストを設定する
+     * 'channel'範囲を設定する
      */
     public function channel(): static
     {
-        return $this->range('channel');
+        return $this->setRange('channel');
     }
 
     /**
-     * @everyone ブロードキャストを設定する
+     * 'everyone'範囲を設定する
      */
     public function everyone(): static
     {
-        return $this->range('everyone');
+        return $this->setRange('everyone');
     }
 
     /**
@@ -69,7 +61,7 @@ class Broadcast extends TextElement
      */
     public function validate(): void
     {
-        if ($this->range === null || $this->range === '') {
+        if ($this->range === null) {
             throw new Exception('Broadcast element must have a range value');
         }
     }
@@ -93,7 +85,7 @@ class Broadcast extends TextElement
         parent::hydrate($data);
 
         if ($data->has('range')) {
-            $this->range($data->useValue('range'));
+            $this->setRange($data->useValue('range'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/Broadcast.php
+++ b/src/Partials/RichTextElements/TextElements/Broadcast.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Broadcast extends TextElement
+{
+    private ?string $range = null;
+
+    /**
+     * 範囲を設定する
+     */
+    public function range(string $range): static
+    {
+        if (!in_array($range, ['here', 'channel', 'everyone'], true)) {
+            throw new Exception('Broadcast range must be one of: here, channel, everyone');
+        }
+
+        $this->range = $range;
+
+        return $this;
+    }
+
+    /**
+     * 範囲を取得する
+     */
+    public function getRange(): ?string
+    {
+        return $this->range;
+    }
+
+    /**
+     * @here ブロードキャストを設定する
+     */
+    public function here(): static
+    {
+        return $this->range('here');
+    }
+
+    /**
+     * @channel ブロードキャストを設定する
+     */
+    public function channel(): static
+    {
+        return $this->range('channel');
+    }
+
+    /**
+     * @everyone ブロードキャストを設定する
+     */
+    public function everyone(): static
+    {
+        return $this->range('everyone');
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'broadcast';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->range === null || $this->range === '') {
+            throw new Exception('Broadcast element must have a range value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['range'] = $this->range;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('range')) {
+            $this->range($data->useValue('range'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Broadcast.php
+++ b/src/Partials/RichTextElements/TextElements/Broadcast.php
@@ -11,7 +11,7 @@ class Broadcast extends TextElement
     private ?string $range = null;
 
     /**
-     * 範囲を設定する
+     * Set broadcast range
      */
     public function setRange(string $range): static
     {
@@ -25,7 +25,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 'here'範囲を設定する
+     * Set range to 'here'
      */
     public function here(): static
     {
@@ -33,7 +33,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 'channel'範囲を設定する
+     * Set range to 'channel'
      */
     public function channel(): static
     {
@@ -41,7 +41,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 'everyone'範囲を設定する
+     * Set range to 'everyone'
      */
     public function everyone(): static
     {
@@ -49,7 +49,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -57,7 +57,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -67,7 +67,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -78,7 +78,7 @@ class Broadcast extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Channel.php
+++ b/src/Partials/RichTextElements/TextElements/Channel.php
@@ -13,7 +13,7 @@ class Channel extends TextElement
     private ?array $style = null;
 
     /**
-     * チャンネルIDを設定する
+     * Set channel ID
      */
     public function setChannelId(string $channelId): static
     {
@@ -23,7 +23,7 @@ class Channel extends TextElement
     }
 
     /**
-     * チャンネルIDを取得する
+     * Get channel ID
      */
     public function getChannelId(): ?string
     {
@@ -31,11 +31,11 @@ class Channel extends TextElement
     }
 
     /**
-     * スタイルを設定する
+     * Set style
      */
     public function setStyle(array $style): static
     {
-        // スタイル属性がブール値であることを確認
+        // Verify that style attributes are boolean values
         foreach ($style as $key => $value) {
             if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
                 throw new Exception('Invalid style property for Channel element: %s', [$key]);
@@ -52,7 +52,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 太字スタイルを設定する
+     * Set bold style
      */
     public function bold(bool $flag = true): static
     {
@@ -63,7 +63,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 斜体スタイルを設定する
+     * Set italic style
      */
     public function italic(bool $flag = true): static
     {
@@ -74,7 +74,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 取り消し線スタイルを設定する
+     * Set strikethrough style
      */
     public function strike(bool $flag = true): static
     {
@@ -85,7 +85,7 @@ class Channel extends TextElement
     }
 
     /**
-     * ハイライトスタイルを設定する
+     * Set highlight style
      */
     public function highlight(bool $flag = true): static
     {
@@ -96,7 +96,7 @@ class Channel extends TextElement
     }
 
     /**
-     * クライアントハイライトスタイルを設定する
+     * Set client highlight style
      */
     public function clientHighlight(bool $flag = true): static
     {
@@ -107,7 +107,7 @@ class Channel extends TextElement
     }
 
     /**
-     * リンク解除スタイルを設定する
+     * Set unlink style
      */
     public function unlink(bool $flag = true): static
     {
@@ -118,7 +118,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -126,7 +126,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -134,7 +134,7 @@ class Channel extends TextElement
             throw new Exception('Channel element must have a channel_id value');
         }
 
-        // スタイルが設定されている場合は検証
+        // Validate style if set
         if ($this->style !== null) {
             foreach ($this->style as $key => $value) {
                 if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
@@ -149,7 +149,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -164,7 +164,7 @@ class Channel extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Channel.php
+++ b/src/Partials/RichTextElements/TextElements/Channel.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Channel extends TextElement
+{
+    private ?string $channelId = null;
+
+    /**
+     * チャンネルIDを設定する
+     */
+    public function channelId(string $channelId): static
+    {
+        $this->channelId = $channelId;
+
+        return $this;
+    }
+
+    /**
+     * チャンネルIDを取得する
+     */
+    public function getChannelId(): ?string
+    {
+        return $this->channelId;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'channel';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->channelId === null || $this->channelId === '') {
+            throw new Exception('Channel element must have a channel_id value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['channel_id'] = $this->channelId;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('channel_id')) {
+            $this->channelId($data->useValue('channel_id'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Channel.php
+++ b/src/Partials/RichTextElements/TextElements/Channel.php
@@ -10,10 +10,12 @@ class Channel extends TextElement
 {
     private ?string $channelId = null;
 
+    private ?array $style = null;
+
     /**
      * チャンネルIDを設定する
      */
-    public function channelId(string $channelId): static
+    public function setChannelId(string $channelId): static
     {
         $this->channelId = $channelId;
 
@@ -29,6 +31,93 @@ class Channel extends TextElement
     }
 
     /**
+     * スタイルを設定する
+     */
+    public function setStyle(array $style): static
+    {
+        // スタイル属性がブール値であることを確認
+        foreach ($style as $key => $value) {
+            if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                throw new Exception('Invalid style property for Channel element: %s', [$key]);
+            }
+
+            if (!is_bool($value)) {
+                throw new Exception('Style property must be a boolean value: %s', [$key]);
+            }
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 太字スタイルを設定する
+     */
+    public function bold(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['bold'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 斜体スタイルを設定する
+     */
+    public function italic(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['italic'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 取り消し線スタイルを設定する
+     */
+    public function strike(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['strike'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * ハイライトスタイルを設定する
+     */
+    public function highlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * クライアントハイライトスタイルを設定する
+     */
+    public function clientHighlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['client_highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * リンク解除スタイルを設定する
+     */
+    public function unlink(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['unlink'] = $flag;
+
+        return $this;
+    }
+
+    /**
      * 要素の型を取得する
      */
     public function getElementType(): string
@@ -41,8 +130,21 @@ class Channel extends TextElement
      */
     public function validate(): void
     {
-        if ($this->channelId === null || $this->channelId === '') {
+        if ($this->channelId === null) {
             throw new Exception('Channel element must have a channel_id value');
+        }
+
+        // スタイルが設定されている場合は検証
+        if ($this->style !== null) {
+            foreach ($this->style as $key => $value) {
+                if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                    throw new Exception('Invalid style property for Channel element: %s', [$key]);
+                }
+
+                if (!is_bool($value)) {
+                    throw new Exception('Style property must be a boolean value: %s', [$key]);
+                }
+            }
         }
     }
 
@@ -53,6 +155,10 @@ class Channel extends TextElement
     {
         $data = parent::toArray();
         $data['channel_id'] = $this->channelId;
+
+        if ($this->style !== null && $this->style !== []) {
+            $data['style'] = $this->style;
+        }
 
         return $data;
     }
@@ -65,7 +171,11 @@ class Channel extends TextElement
         parent::hydrate($data);
 
         if ($data->has('channel_id')) {
-            $this->channelId($data->useValue('channel_id'));
+            $this->setChannelId($data->useValue('channel_id'));
+        }
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useArray('style'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/Color.php
+++ b/src/Partials/RichTextElements/TextElements/Color.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Color extends TextElement
+{
+    private ?string $value = null;
+
+    /**
+     * カラー値を設定する
+     */
+    public function setValue(string $value): static
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * 色の値を取得する
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'color';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->value === null) {
+            throw new Exception('Color element must have a value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['value'] = $this->value;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('value')) {
+            $this->setValue($data->useValue('value'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Color.php
+++ b/src/Partials/RichTextElements/TextElements/Color.php
@@ -11,7 +11,7 @@ class Color extends TextElement
     private ?string $value = null;
 
     /**
-     * カラー値を設定する
+     * Set color value
      */
     public function setValue(string $value): static
     {
@@ -21,7 +21,7 @@ class Color extends TextElement
     }
 
     /**
-     * 色の値を取得する
+     * Get color value
      */
     public function getValue(): ?string
     {
@@ -29,7 +29,7 @@ class Color extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -37,7 +37,7 @@ class Color extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -47,7 +47,7 @@ class Color extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -58,7 +58,7 @@ class Color extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Date.php
+++ b/src/Partials/RichTextElements/TextElements/Date.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Date extends TextElement
+{
+    private ?string $timestamp = null;
+
+    private ?string $format = null;
+
+    private ?string $link = null;
+
+    /**
+     * タイムスタンプを設定する
+     */
+    public function timestamp(string $timestamp): static
+    {
+        $this->timestamp = $timestamp;
+
+        return $this;
+    }
+
+    /**
+     * タイムスタンプを取得する
+     */
+    public function getTimestamp(): ?string
+    {
+        return $this->timestamp;
+    }
+
+    /**
+     * フォーマットを設定する
+     */
+    public function format(string $format): static
+    {
+        $this->format = $format;
+
+        return $this;
+    }
+
+    /**
+     * フォーマットを取得する
+     */
+    public function getFormat(): ?string
+    {
+        return $this->format;
+    }
+
+    /**
+     * リンクを設定する
+     */
+    public function link(string $link): static
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+
+    /**
+     * リンクを取得する
+     */
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'date';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->timestamp === null || $this->timestamp === '') {
+            throw new Exception('Date element must have a timestamp value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['timestamp'] = $this->timestamp;
+
+        if ($this->format !== null) {
+            $data['format'] = $this->format;
+        }
+
+        if ($this->link !== null) {
+            $data['link'] = $this->link;
+        }
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('timestamp')) {
+            $this->timestamp($data->useValue('timestamp'));
+        }
+
+        if ($data->has('format')) {
+            $this->format($data->useValue('format'));
+        }
+
+        if ($data->has('link')) {
+            $this->link($data->useValue('link'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Date.php
+++ b/src/Partials/RichTextElements/TextElements/Date.php
@@ -8,16 +8,18 @@ use SlackPhp\BlockKit\{Exception, HydrationData};
 
 class Date extends TextElement
 {
-    private ?string $timestamp = null;
+    private ?int $timestamp = null;
 
     private ?string $format = null;
 
-    private ?string $link = null;
+    private ?string $url = null;
+
+    private ?string $fallback = null;
 
     /**
      * タイムスタンプを設定する
      */
-    public function timestamp(string $timestamp): static
+    public function setTimestamp(int $timestamp): static
     {
         $this->timestamp = $timestamp;
 
@@ -25,47 +27,37 @@ class Date extends TextElement
     }
 
     /**
-     * タイムスタンプを取得する
-     */
-    public function getTimestamp(): ?string
-    {
-        return $this->timestamp;
-    }
-
-    /**
      * フォーマットを設定する
      */
-    public function format(string $format): static
+    public function setFormat(string $format): static
     {
+        if ($format === '') {
+            throw new Exception('Date format cannot be empty');
+        }
+
         $this->format = $format;
 
         return $this;
     }
 
     /**
-     * フォーマットを取得する
+     * URLを設定する
      */
-    public function getFormat(): ?string
+    public function setUrl(string $url): static
     {
-        return $this->format;
-    }
-
-    /**
-     * リンクを設定する
-     */
-    public function link(string $link): static
-    {
-        $this->link = $link;
+        $this->url = $url;
 
         return $this;
     }
 
     /**
-     * リンクを取得する
+     * フォールバックテキストを設定する
      */
-    public function getLink(): ?string
+    public function setFallback(string $fallback): static
     {
-        return $this->link;
+        $this->fallback = $fallback;
+
+        return $this;
     }
 
     /**
@@ -81,8 +73,12 @@ class Date extends TextElement
      */
     public function validate(): void
     {
-        if ($this->timestamp === null || $this->timestamp === '') {
+        if ($this->timestamp === null) {
             throw new Exception('Date element must have a timestamp value');
+        }
+
+        if ($this->format === null) {
+            throw new Exception('Date element must have a format value');
         }
     }
 
@@ -93,13 +89,14 @@ class Date extends TextElement
     {
         $data = parent::toArray();
         $data['timestamp'] = $this->timestamp;
+        $data['format'] = $this->format;
 
-        if ($this->format !== null) {
-            $data['format'] = $this->format;
+        if ($this->url !== null) {
+            $data['url'] = $this->url;
         }
 
-        if ($this->link !== null) {
-            $data['link'] = $this->link;
+        if ($this->fallback !== null) {
+            $data['fallback'] = $this->fallback;
         }
 
         return $data;
@@ -113,15 +110,19 @@ class Date extends TextElement
         parent::hydrate($data);
 
         if ($data->has('timestamp')) {
-            $this->timestamp($data->useValue('timestamp'));
+            $this->setTimestamp($data->useValue('timestamp'));
         }
 
         if ($data->has('format')) {
-            $this->format($data->useValue('format'));
+            $this->setFormat($data->useValue('format'));
         }
 
-        if ($data->has('link')) {
-            $this->link($data->useValue('link'));
+        if ($data->has('url')) {
+            $this->setUrl($data->useValue('url'));
+        }
+
+        if ($data->has('fallback')) {
+            $this->setFallback($data->useValue('fallback'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/Date.php
+++ b/src/Partials/RichTextElements/TextElements/Date.php
@@ -17,7 +17,7 @@ class Date extends TextElement
     private ?string $fallback = null;
 
     /**
-     * タイムスタンプを設定する
+     * Set timestamp
      */
     public function setTimestamp(int $timestamp): static
     {
@@ -27,7 +27,7 @@ class Date extends TextElement
     }
 
     /**
-     * フォーマットを設定する
+     * Set format
      */
     public function setFormat(string $format): static
     {
@@ -41,7 +41,7 @@ class Date extends TextElement
     }
 
     /**
-     * URLを設定する
+     * Set URL
      */
     public function setUrl(string $url): static
     {
@@ -51,7 +51,7 @@ class Date extends TextElement
     }
 
     /**
-     * フォールバックテキストを設定する
+     * Set fallback text
      */
     public function setFallback(string $fallback): static
     {
@@ -61,7 +61,7 @@ class Date extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -69,7 +69,7 @@ class Date extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -83,7 +83,7 @@ class Date extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -103,7 +103,7 @@ class Date extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Emoji.php
+++ b/src/Partials/RichTextElements/TextElements/Emoji.php
@@ -13,7 +13,7 @@ class Emoji extends TextElement
     private ?string $unicode = null;
 
     /**
-     * 絵文字名を設定する
+     * Set emoji name
      */
     public function setName(string $name): static
     {
@@ -23,7 +23,7 @@ class Emoji extends TextElement
     }
 
     /**
-     * Unicode値を設定する
+     * Set Unicode value
      */
     public function setUnicode(string $unicode): static
     {
@@ -33,7 +33,7 @@ class Emoji extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -41,7 +41,7 @@ class Emoji extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -51,7 +51,7 @@ class Emoji extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -66,7 +66,7 @@ class Emoji extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Emoji.php
+++ b/src/Partials/RichTextElements/TextElements/Emoji.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Emoji extends TextElement
+{
+    private ?string $name = null;
+
+    /**
+     * 絵文字名を設定する
+     */
+    public function name(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * 絵文字名を取得する
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'emoji';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->name === null || $this->name === '') {
+            throw new Exception('Emoji element must have a name value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['name'] = $this->name;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('name')) {
+            $this->name($data->useValue('name'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Emoji.php
+++ b/src/Partials/RichTextElements/TextElements/Emoji.php
@@ -10,10 +10,12 @@ class Emoji extends TextElement
 {
     private ?string $name = null;
 
+    private ?string $unicode = null;
+
     /**
      * 絵文字名を設定する
      */
-    public function name(string $name): static
+    public function setName(string $name): static
     {
         $this->name = $name;
 
@@ -21,11 +23,13 @@ class Emoji extends TextElement
     }
 
     /**
-     * 絵文字名を取得する
+     * Unicode値を設定する
      */
-    public function getName(): ?string
+    public function setUnicode(string $unicode): static
     {
-        return $this->name;
+        $this->unicode = $unicode;
+
+        return $this;
     }
 
     /**
@@ -41,7 +45,7 @@ class Emoji extends TextElement
      */
     public function validate(): void
     {
-        if ($this->name === null || $this->name === '') {
+        if ($this->name === null) {
             throw new Exception('Emoji element must have a name value');
         }
     }
@@ -54,6 +58,10 @@ class Emoji extends TextElement
         $data = parent::toArray();
         $data['name'] = $this->name;
 
+        if ($this->unicode !== null) {
+            $data['unicode'] = $this->unicode;
+        }
+
         return $data;
     }
 
@@ -65,7 +73,11 @@ class Emoji extends TextElement
         parent::hydrate($data);
 
         if ($data->has('name')) {
-            $this->name($data->useValue('name'));
+            $this->setName($data->useValue('name'));
+        }
+
+        if ($data->has('unicode')) {
+            $this->setUnicode($data->useValue('unicode'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/Link.php
+++ b/src/Partials/RichTextElements/TextElements/Link.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Link extends TextElement
+{
+    private ?string $url = null;
+
+    private ?string $text = null;
+
+    /**
+     * URLを設定する
+     */
+    public function url(string $url): static
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * URLを取得する
+     */
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * テキストを設定する
+     */
+    public function text(string $text): static
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * テキストを取得する
+     */
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'link';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->url === null || $this->url === '') {
+            throw new Exception('Link element must have a url value');
+        }
+
+        if ($this->text === null || $this->text === '') {
+            throw new Exception('Link element must have a text value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['url'] = $this->url;
+        $data['text'] = $this->text;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('url')) {
+            $this->url($data->useValue('url'));
+        }
+
+        if ($data->has('text')) {
+            $this->text($data->useValue('text'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Link.php
+++ b/src/Partials/RichTextElements/TextElements/Link.php
@@ -17,7 +17,7 @@ class Link extends TextElement
     private ?array $style = null;
 
     /**
-     * URLを設定する
+     * Set URL
      */
     public function url(string $url): static
     {
@@ -27,7 +27,7 @@ class Link extends TextElement
     }
 
     /**
-     * URLを取得する
+     * Get URL
      */
     public function getUrl(): ?string
     {
@@ -35,7 +35,7 @@ class Link extends TextElement
     }
 
     /**
-     * テキストを設定する
+     * Set text
      */
     public function text(string $text): static
     {
@@ -45,7 +45,7 @@ class Link extends TextElement
     }
 
     /**
-     * テキストを取得する
+     * Get text
      */
     public function getText(): ?string
     {
@@ -53,7 +53,7 @@ class Link extends TextElement
     }
 
     /**
-     * 安全でないリンクかどうかを設定する
+     * Set whether the link is unsafe
      */
     public function setUnsafe(bool $unsafe): static
     {
@@ -63,11 +63,11 @@ class Link extends TextElement
     }
 
     /**
-     * スタイルを設定する
+     * Set style
      */
     public function setStyle(array $style): static
     {
-        // スタイル属性がブール値であることを確認
+        // Verify that style attributes are boolean values
         foreach ($style as $key => $value) {
             if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
                 throw new Exception('Invalid style property for Link element: %s', [$key]);
@@ -84,7 +84,7 @@ class Link extends TextElement
     }
 
     /**
-     * 太字スタイルを設定する
+     * Set bold style
      */
     public function bold(bool $flag = true): static
     {
@@ -95,7 +95,7 @@ class Link extends TextElement
     }
 
     /**
-     * 斜体スタイルを設定する
+     * Set italic style
      */
     public function italic(bool $flag = true): static
     {
@@ -106,7 +106,7 @@ class Link extends TextElement
     }
 
     /**
-     * 取り消し線スタイルを設定する
+     * Set strikethrough style
      */
     public function strike(bool $flag = true): static
     {
@@ -117,7 +117,7 @@ class Link extends TextElement
     }
 
     /**
-     * コードスタイルを設定する
+     * Set code style
      */
     public function code(bool $flag = true): static
     {
@@ -128,7 +128,7 @@ class Link extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -136,16 +136,16 @@ class Link extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
         if ($this->url === null || $this->url === '') {
             throw new Exception('Link element must have a url value');
         }
-        // text は仕様では任意なので、検証しない
+        // text is optional according to the specification, so no validation needed
 
-        // スタイルが設定されている場合は検証
+        // Validate style if set
         if ($this->style !== null) {
             foreach ($this->style as $key => $value) {
                 if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
@@ -160,14 +160,14 @@ class Link extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
         $data = parent::toArray();
         $data['url'] = $this->url;
 
-        // text は任意なので、設定されている場合のみ含める
+        // text is optional, so only include if set
         if ($this->text !== null) {
             $data['text'] = $this->text;
         }
@@ -184,7 +184,7 @@ class Link extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/Link.php
+++ b/src/Partials/RichTextElements/TextElements/Link.php
@@ -12,6 +12,10 @@ class Link extends TextElement
 
     private ?string $text = null;
 
+    private ?bool $unsafe = null;
+
+    private ?array $style = null;
+
     /**
      * URLを設定する
      */
@@ -49,6 +53,81 @@ class Link extends TextElement
     }
 
     /**
+     * 安全でないリンクかどうかを設定する
+     */
+    public function setUnsafe(bool $unsafe): static
+    {
+        $this->unsafe = $unsafe;
+
+        return $this;
+    }
+
+    /**
+     * スタイルを設定する
+     */
+    public function setStyle(array $style): static
+    {
+        // スタイル属性がブール値であることを確認
+        foreach ($style as $key => $value) {
+            if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
+                throw new Exception('Invalid style property for Link element: %s', [$key]);
+            }
+
+            if (!is_bool($value)) {
+                throw new Exception('Style property must be a boolean value: %s', [$key]);
+            }
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 太字スタイルを設定する
+     */
+    public function bold(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['bold'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 斜体スタイルを設定する
+     */
+    public function italic(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['italic'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 取り消し線スタイルを設定する
+     */
+    public function strike(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['strike'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * コードスタイルを設定する
+     */
+    public function code(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['code'] = $flag;
+
+        return $this;
+    }
+
+    /**
      * 要素の型を取得する
      */
     public function getElementType(): string
@@ -64,9 +143,19 @@ class Link extends TextElement
         if ($this->url === null || $this->url === '') {
             throw new Exception('Link element must have a url value');
         }
+        // text は仕様では任意なので、検証しない
 
-        if ($this->text === null || $this->text === '') {
-            throw new Exception('Link element must have a text value');
+        // スタイルが設定されている場合は検証
+        if ($this->style !== null) {
+            foreach ($this->style as $key => $value) {
+                if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
+                    throw new Exception('Invalid style property for Link element: %s', [$key]);
+                }
+
+                if (!is_bool($value)) {
+                    throw new Exception('Style property must be a boolean value: %s', [$key]);
+                }
+            }
         }
     }
 
@@ -77,7 +166,19 @@ class Link extends TextElement
     {
         $data = parent::toArray();
         $data['url'] = $this->url;
-        $data['text'] = $this->text;
+
+        // text は任意なので、設定されている場合のみ含める
+        if ($this->text !== null) {
+            $data['text'] = $this->text;
+        }
+
+        if ($this->unsafe !== null) {
+            $data['unsafe'] = $this->unsafe;
+        }
+
+        if ($this->style !== null && $this->style !== []) {
+            $data['style'] = $this->style;
+        }
 
         return $data;
     }
@@ -95,6 +196,14 @@ class Link extends TextElement
 
         if ($data->has('text')) {
             $this->text($data->useValue('text'));
+        }
+
+        if ($data->has('unsafe')) {
+            $this->setUnsafe($data->useValue('unsafe'));
+        }
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useArray('style'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/Text.php
+++ b/src/Partials/RichTextElements/TextElements/Text.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class Text extends TextElement
+{
+    private ?string $text = null;
+
+    private ?array $style = null;
+
+    /**
+     * テキストを設定する
+     */
+    public function text(string $text): static
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    /**
+     * テキストを取得する
+     */
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    /**
+     * スタイルを設定する
+     */
+    public function setStyle(array $style): static
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 太字スタイルを設定する
+     */
+    public function bold(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['bold'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 斜体スタイルを設定する
+     */
+    public function italic(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['italic'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 取り消し線スタイルを設定する
+     */
+    public function strike(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['strike'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * コードスタイルを設定する
+     */
+    public function code(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['code'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'text';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->text === null || $this->text === '') {
+            throw new Exception('Text element must have a text value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['text'] = $this->text;
+
+        if ($this->style !== null && $this->style !== []) {
+            $data['style'] = $this->style;
+        }
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('text')) {
+            $this->text($data->useValue('text'));
+        }
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useArray('style'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/Text.php
+++ b/src/Partials/RichTextElements/TextElements/Text.php
@@ -35,6 +35,17 @@ class Text extends TextElement
      */
     public function setStyle(array $style): static
     {
+        // スタイル属性がブール値であることを確認
+        foreach ($style as $key => $value) {
+            if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
+                throw new Exception('Invalid style property for Text element: %s', [$key]);
+            }
+
+            if (!is_bool($value)) {
+                throw new Exception('Style property must be a boolean value: %s', [$key]);
+            }
+        }
+
         $this->style = $style;
 
         return $this;
@@ -99,6 +110,19 @@ class Text extends TextElement
     {
         if ($this->text === null || $this->text === '') {
             throw new Exception('Text element must have a text value');
+        }
+
+        // スタイルが設定されている場合は検証
+        if ($this->style !== null) {
+            foreach ($this->style as $key => $value) {
+                if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
+                    throw new Exception('Invalid style property for Text element: %s', [$key]);
+                }
+
+                if (!is_bool($value)) {
+                    throw new Exception('Style property must be a boolean value: %s', [$key]);
+                }
+            }
         }
     }
 

--- a/src/Partials/RichTextElements/TextElements/Text.php
+++ b/src/Partials/RichTextElements/TextElements/Text.php
@@ -13,7 +13,7 @@ class Text extends TextElement
     private ?array $style = null;
 
     /**
-     * テキストを設定する
+     * Set text
      */
     public function text(string $text): static
     {
@@ -23,7 +23,7 @@ class Text extends TextElement
     }
 
     /**
-     * テキストを取得する
+     * Get text
      */
     public function getText(): ?string
     {
@@ -31,11 +31,11 @@ class Text extends TextElement
     }
 
     /**
-     * スタイルを設定する
+     * Set style
      */
     public function setStyle(array $style): static
     {
-        // スタイル属性がブール値であることを確認
+        // Verify that style attributes are boolean values
         foreach ($style as $key => $value) {
             if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
                 throw new Exception('Invalid style property for Text element: %s', [$key]);
@@ -52,7 +52,7 @@ class Text extends TextElement
     }
 
     /**
-     * 太字スタイルを設定する
+     * Set bold style
      */
     public function bold(bool $flag = true): static
     {
@@ -63,7 +63,7 @@ class Text extends TextElement
     }
 
     /**
-     * 斜体スタイルを設定する
+     * Set italic style
      */
     public function italic(bool $flag = true): static
     {
@@ -74,7 +74,7 @@ class Text extends TextElement
     }
 
     /**
-     * 取り消し線スタイルを設定する
+     * Set strikethrough style
      */
     public function strike(bool $flag = true): static
     {
@@ -85,7 +85,7 @@ class Text extends TextElement
     }
 
     /**
-     * コードスタイルを設定する
+     * Set code style
      */
     public function code(bool $flag = true): static
     {
@@ -96,7 +96,7 @@ class Text extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -104,7 +104,7 @@ class Text extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -112,7 +112,7 @@ class Text extends TextElement
             throw new Exception('Text element must have a text value');
         }
 
-        // スタイルが設定されている場合は検証
+        // Validate style if set
         if ($this->style !== null) {
             foreach ($this->style as $key => $value) {
                 if (!in_array($key, ['bold', 'italic', 'strike', 'code'], true)) {
@@ -127,7 +127,7 @@ class Text extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -142,7 +142,7 @@ class Text extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/TextElement.php
+++ b/src/Partials/RichTextElements/TextElements/TextElement.php
@@ -9,12 +9,12 @@ use SlackPhp\BlockKit\{Element, Exception, HydrationData};
 abstract class TextElement extends Element
 {
     /**
-     * 要素の型を取得する
+     * Get the element type
      */
     abstract public function getElementType(): string;
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -25,10 +25,10 @@ abstract class TextElement extends Element
     }
 
     /**
-     * 型から対応するTextElement要素を作成する
+     * Create a TextElement from the specified type
      *
-     * @param  string    $type 要素の型
-     * @return static    作成された要素
+     * @param  string    $type Element type
+     * @return static    Created element
      * @throws Exception
      */
     public static function createFromType(string $type): static
@@ -44,10 +44,10 @@ abstract class TextElement extends Element
     }
 
     /**
-     * 型に対応するクラス名を取得する
+     * Get the class name corresponding to the type
      *
-     * @param  string $type 要素の型
-     * @return string クラス名
+     * @param  string $type Element type
+     * @return string Class name
      */
     protected static function getClassForType(string $type): string
     {

--- a/src/Partials/RichTextElements/TextElements/TextElement.php
+++ b/src/Partials/RichTextElements/TextElements/TextElement.php
@@ -28,9 +28,10 @@ abstract class TextElement extends Element
      * 型から対応するTextElement要素を作成する
      *
      * @param  string    $type 要素の型
+     * @return static    作成された要素
      * @throws Exception
      */
-    public static function createFromType(string $type): self
+    public static function createFromType(string $type): static
     {
         $class = self::getClassForType($type);
 
@@ -38,7 +39,7 @@ abstract class TextElement extends Element
             throw new Exception('Unknown text element type: %s', [$type]);
         }
 
-        /** @var TextElement $element */
+        // @phpstan-ignore-next-line
         return new $class();
     }
 
@@ -59,6 +60,7 @@ abstract class TextElement extends Element
             'usergroup' => UserGroup::class,
             'date' => Date::class,
             'broadcast' => Broadcast::class,
+            'color' => Color::class,
         ];
 
         return $map[$type] ?? '';

--- a/src/Partials/RichTextElements/TextElements/TextElement.php
+++ b/src/Partials/RichTextElements/TextElements/TextElement.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Element, Exception, HydrationData};
+
+abstract class TextElement extends Element
+{
+    /**
+     * 要素の型を取得する
+     */
+    abstract public function getElementType(): string;
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['type'] = $this->getElementType();
+
+        return $data;
+    }
+
+    /**
+     * 型から対応するTextElement要素を作成する
+     *
+     * @param  string    $type 要素の型
+     * @throws Exception
+     */
+    public static function createFromType(string $type): self
+    {
+        $class = self::getClassForType($type);
+
+        if (!class_exists($class)) {
+            throw new Exception('Unknown text element type: %s', [$type]);
+        }
+
+        /** @var TextElement $element */
+        return new $class();
+    }
+
+    /**
+     * 型に対応するクラス名を取得する
+     *
+     * @param  string $type 要素の型
+     * @return string クラス名
+     */
+    protected static function getClassForType(string $type): string
+    {
+        $map = [
+            'text' => Text::class,
+            'channel' => Channel::class,
+            'user' => User::class,
+            'emoji' => Emoji::class,
+            'link' => Link::class,
+            'usergroup' => UserGroup::class,
+            'date' => Date::class,
+            'broadcast' => Broadcast::class,
+        ];
+
+        return $map[$type] ?? '';
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/User.php
+++ b/src/Partials/RichTextElements/TextElements/User.php
@@ -13,7 +13,7 @@ class User extends TextElement
     private ?array $style = null;
 
     /**
-     * ユーザーIDを設定する
+     * Set user ID
      */
     public function setUserId(string $userId): static
     {
@@ -23,7 +23,7 @@ class User extends TextElement
     }
 
     /**
-     * ユーザーIDを取得する
+     * Get user ID
      */
     public function getUserId(): ?string
     {
@@ -31,11 +31,11 @@ class User extends TextElement
     }
 
     /**
-     * スタイルを設定する
+     * Set style
      */
     public function setStyle(array $style): static
     {
-        // スタイル属性がブール値であることを確認
+        // Verify that style attributes are boolean values
         foreach ($style as $key => $value) {
             if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
                 throw new Exception('Invalid style property for User element: %s', [$key]);
@@ -52,7 +52,7 @@ class User extends TextElement
     }
 
     /**
-     * 太字スタイルを設定する
+     * Set bold style
      */
     public function bold(bool $flag = true): static
     {
@@ -63,7 +63,7 @@ class User extends TextElement
     }
 
     /**
-     * 斜体スタイルを設定する
+     * Set italic style
      */
     public function italic(bool $flag = true): static
     {
@@ -74,7 +74,7 @@ class User extends TextElement
     }
 
     /**
-     * 取り消し線スタイルを設定する
+     * Set strikethrough style
      */
     public function strike(bool $flag = true): static
     {
@@ -85,7 +85,7 @@ class User extends TextElement
     }
 
     /**
-     * ハイライトスタイルを設定する
+     * Set highlight style
      */
     public function highlight(bool $flag = true): static
     {
@@ -96,7 +96,7 @@ class User extends TextElement
     }
 
     /**
-     * クライアントハイライトスタイルを設定する
+     * Set client highlight style
      */
     public function clientHighlight(bool $flag = true): static
     {
@@ -107,7 +107,7 @@ class User extends TextElement
     }
 
     /**
-     * リンク解除スタイルを設定する
+     * Set unlink style
      */
     public function unlink(bool $flag = true): static
     {
@@ -118,7 +118,7 @@ class User extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -126,7 +126,7 @@ class User extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -134,7 +134,7 @@ class User extends TextElement
             throw new Exception('User element must have a user_id value');
         }
 
-        // スタイルが設定されている場合は検証
+        // Validate style if set
         if ($this->style !== null) {
             foreach ($this->style as $key => $value) {
                 if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
@@ -149,7 +149,7 @@ class User extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -164,7 +164,7 @@ class User extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Partials/RichTextElements/TextElements/User.php
+++ b/src/Partials/RichTextElements/TextElements/User.php
@@ -10,10 +10,12 @@ class User extends TextElement
 {
     private ?string $userId = null;
 
+    private ?array $style = null;
+
     /**
      * ユーザーIDを設定する
      */
-    public function userId(string $userId): static
+    public function setUserId(string $userId): static
     {
         $this->userId = $userId;
 
@@ -29,6 +31,93 @@ class User extends TextElement
     }
 
     /**
+     * スタイルを設定する
+     */
+    public function setStyle(array $style): static
+    {
+        // スタイル属性がブール値であることを確認
+        foreach ($style as $key => $value) {
+            if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                throw new Exception('Invalid style property for User element: %s', [$key]);
+            }
+
+            if (!is_bool($value)) {
+                throw new Exception('Style property must be a boolean value: %s', [$key]);
+            }
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 太字スタイルを設定する
+     */
+    public function bold(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['bold'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 斜体スタイルを設定する
+     */
+    public function italic(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['italic'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 取り消し線スタイルを設定する
+     */
+    public function strike(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['strike'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * ハイライトスタイルを設定する
+     */
+    public function highlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * クライアントハイライトスタイルを設定する
+     */
+    public function clientHighlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['client_highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * リンク解除スタイルを設定する
+     */
+    public function unlink(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['unlink'] = $flag;
+
+        return $this;
+    }
+
+    /**
      * 要素の型を取得する
      */
     public function getElementType(): string
@@ -41,8 +130,21 @@ class User extends TextElement
      */
     public function validate(): void
     {
-        if ($this->userId === null || $this->userId === '') {
+        if ($this->userId === null) {
             throw new Exception('User element must have a user_id value');
+        }
+
+        // スタイルが設定されている場合は検証
+        if ($this->style !== null) {
+            foreach ($this->style as $key => $value) {
+                if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                    throw new Exception('Invalid style property for User element: %s', [$key]);
+                }
+
+                if (!is_bool($value)) {
+                    throw new Exception('Style property must be a boolean value: %s', [$key]);
+                }
+            }
         }
     }
 
@@ -53,6 +155,10 @@ class User extends TextElement
     {
         $data = parent::toArray();
         $data['user_id'] = $this->userId;
+
+        if ($this->style !== null && $this->style !== []) {
+            $data['style'] = $this->style;
+        }
 
         return $data;
     }
@@ -65,7 +171,11 @@ class User extends TextElement
         parent::hydrate($data);
 
         if ($data->has('user_id')) {
-            $this->userId($data->useValue('user_id'));
+            $this->setUserId($data->useValue('user_id'));
+        }
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useArray('style'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/User.php
+++ b/src/Partials/RichTextElements/TextElements/User.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class User extends TextElement
+{
+    private ?string $userId = null;
+
+    /**
+     * ユーザーIDを設定する
+     */
+    public function userId(string $userId): static
+    {
+        $this->userId = $userId;
+
+        return $this;
+    }
+
+    /**
+     * ユーザーIDを取得する
+     */
+    public function getUserId(): ?string
+    {
+        return $this->userId;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'user';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->userId === null || $this->userId === '') {
+            throw new Exception('User element must have a user_id value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['user_id'] = $this->userId;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('user_id')) {
+            $this->userId($data->useValue('user_id'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/UserGroup.php
+++ b/src/Partials/RichTextElements/TextElements/UserGroup.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\{Exception, HydrationData};
+
+class UserGroup extends TextElement
+{
+    private ?string $usergroupId = null;
+
+    /**
+     * ユーザーグループIDを設定する
+     */
+    public function usergroupId(string $usergroupId): static
+    {
+        $this->usergroupId = $usergroupId;
+
+        return $this;
+    }
+
+    /**
+     * ユーザーグループIDを取得する
+     */
+    public function getUsergroupId(): ?string
+    {
+        return $this->usergroupId;
+    }
+
+    /**
+     * 要素の型を取得する
+     */
+    public function getElementType(): string
+    {
+        return 'usergroup';
+    }
+
+    /**
+     * 要素を検証する
+     */
+    public function validate(): void
+    {
+        if ($this->usergroupId === null || $this->usergroupId === '') {
+            throw new Exception('UserGroup element must have a usergroup_id value');
+        }
+    }
+
+    /**
+     * 要素を配列に変換する
+     */
+    public function toArray(): array
+    {
+        $data = parent::toArray();
+        $data['usergroup_id'] = $this->usergroupId;
+
+        return $data;
+    }
+
+    /**
+     * 配列から要素を生成する
+     */
+    protected function hydrate(HydrationData $data): void
+    {
+        parent::hydrate($data);
+
+        if ($data->has('usergroup_id')) {
+            $this->usergroupId($data->useValue('usergroup_id'));
+        }
+    }
+}

--- a/src/Partials/RichTextElements/TextElements/UserGroup.php
+++ b/src/Partials/RichTextElements/TextElements/UserGroup.php
@@ -10,10 +10,12 @@ class UserGroup extends TextElement
 {
     private ?string $usergroupId = null;
 
+    private ?array $style = null;
+
     /**
      * ユーザーグループIDを設定する
      */
-    public function usergroupId(string $usergroupId): static
+    public function setUsergroupId(string $usergroupId): static
     {
         $this->usergroupId = $usergroupId;
 
@@ -29,6 +31,93 @@ class UserGroup extends TextElement
     }
 
     /**
+     * スタイルを設定する
+     */
+    public function setStyle(array $style): static
+    {
+        // スタイル属性がブール値であることを確認
+        foreach ($style as $key => $value) {
+            if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                throw new Exception('Invalid style property for UserGroup element: %s', [$key]);
+            }
+
+            if (!is_bool($value)) {
+                throw new Exception('Style property must be a boolean value: %s', [$key]);
+            }
+        }
+
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * 太字スタイルを設定する
+     */
+    public function bold(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['bold'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 斜体スタイルを設定する
+     */
+    public function italic(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['italic'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * 取り消し線スタイルを設定する
+     */
+    public function strike(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['strike'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * ハイライトスタイルを設定する
+     */
+    public function highlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * クライアントハイライトスタイルを設定する
+     */
+    public function clientHighlight(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['client_highlight'] = $flag;
+
+        return $this;
+    }
+
+    /**
+     * リンク解除スタイルを設定する
+     */
+    public function unlink(bool $flag = true): static
+    {
+        $this->style ??= [];
+        $this->style['unlink'] = $flag;
+
+        return $this;
+    }
+
+    /**
      * 要素の型を取得する
      */
     public function getElementType(): string
@@ -41,8 +130,21 @@ class UserGroup extends TextElement
      */
     public function validate(): void
     {
-        if ($this->usergroupId === null || $this->usergroupId === '') {
+        if ($this->usergroupId === null) {
             throw new Exception('UserGroup element must have a usergroup_id value');
+        }
+
+        // スタイルが設定されている場合は検証
+        if ($this->style !== null) {
+            foreach ($this->style as $key => $value) {
+                if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
+                    throw new Exception('Invalid style property for UserGroup element: %s', [$key]);
+                }
+
+                if (!is_bool($value)) {
+                    throw new Exception('Style property must be a boolean value: %s', [$key]);
+                }
+            }
         }
     }
 
@@ -53,6 +155,10 @@ class UserGroup extends TextElement
     {
         $data = parent::toArray();
         $data['usergroup_id'] = $this->usergroupId;
+
+        if ($this->style !== null && $this->style !== []) {
+            $data['style'] = $this->style;
+        }
 
         return $data;
     }
@@ -65,7 +171,11 @@ class UserGroup extends TextElement
         parent::hydrate($data);
 
         if ($data->has('usergroup_id')) {
-            $this->usergroupId($data->useValue('usergroup_id'));
+            $this->setUsergroupId($data->useValue('usergroup_id'));
+        }
+
+        if ($data->has('style')) {
+            $this->setStyle($data->useArray('style'));
         }
     }
 }

--- a/src/Partials/RichTextElements/TextElements/UserGroup.php
+++ b/src/Partials/RichTextElements/TextElements/UserGroup.php
@@ -13,7 +13,7 @@ class UserGroup extends TextElement
     private ?array $style = null;
 
     /**
-     * ユーザーグループIDを設定する
+     * Set user group ID
      */
     public function setUsergroupId(string $usergroupId): static
     {
@@ -23,7 +23,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * ユーザーグループIDを取得する
+     * Get user group ID
      */
     public function getUsergroupId(): ?string
     {
@@ -31,11 +31,11 @@ class UserGroup extends TextElement
     }
 
     /**
-     * スタイルを設定する
+     * Set style
      */
     public function setStyle(array $style): static
     {
-        // スタイル属性がブール値であることを確認
+        // Verify that style attributes are boolean values
         foreach ($style as $key => $value) {
             if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
                 throw new Exception('Invalid style property for UserGroup element: %s', [$key]);
@@ -52,7 +52,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 太字スタイルを設定する
+     * Set bold style
      */
     public function bold(bool $flag = true): static
     {
@@ -63,7 +63,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 斜体スタイルを設定する
+     * Set italic style
      */
     public function italic(bool $flag = true): static
     {
@@ -74,7 +74,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 取り消し線スタイルを設定する
+     * Set strikethrough style
      */
     public function strike(bool $flag = true): static
     {
@@ -85,7 +85,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * ハイライトスタイルを設定する
+     * Set highlight style
      */
     public function highlight(bool $flag = true): static
     {
@@ -96,7 +96,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * クライアントハイライトスタイルを設定する
+     * Set client highlight style
      */
     public function clientHighlight(bool $flag = true): static
     {
@@ -107,7 +107,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * リンク解除スタイルを設定する
+     * Set unlink style
      */
     public function unlink(bool $flag = true): static
     {
@@ -118,7 +118,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 要素の型を取得する
+     * Get element type
      */
     public function getElementType(): string
     {
@@ -126,7 +126,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 要素を検証する
+     * Validate the element
      */
     public function validate(): void
     {
@@ -134,7 +134,7 @@ class UserGroup extends TextElement
             throw new Exception('UserGroup element must have a usergroup_id value');
         }
 
-        // スタイルが設定されている場合は検証
+        // Validate style if set
         if ($this->style !== null) {
             foreach ($this->style as $key => $value) {
                 if (!in_array($key, ['bold', 'italic', 'strike', 'highlight', 'client_highlight', 'unlink'], true)) {
@@ -149,7 +149,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 要素を配列に変換する
+     * Convert the element to an array
      */
     public function toArray(): array
     {
@@ -164,7 +164,7 @@ class UserGroup extends TextElement
     }
 
     /**
-     * 配列から要素を生成する
+     * Generate an element from an array
      */
     protected function hydrate(HydrationData $data): void
     {

--- a/src/Surfaces/Surface.php
+++ b/src/Surfaces/Surface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SlackPhp\BlockKit\Surfaces;
 
-use SlackPhp\BlockKit\Blocks\{Actions, BlockElement, Context, Divider, Header, Image, Input, Section};
+use SlackPhp\BlockKit\Blocks\{Actions, BlockElement, Context, Divider, Header, Image, Input, Section, RichText};
 use SlackPhp\BlockKit\Blocks\Virtual\{VirtualBlock, TwoColumnTable};
 use SlackPhp\BlockKit\{
     Exception,
@@ -105,6 +105,14 @@ abstract class Surface extends Element
     public function newInput(?string $blockId = null): Input
     {
         $block = new Input($blockId);
+        $this->add($block);
+
+        return $block;
+    }
+
+    public function newRichText(?string $blockId = null): RichText
+    {
+        $block = new RichText($blockId);
         $this->add($block);
 
         return $block;

--- a/src/Type.php
+++ b/src/Type.php
@@ -24,6 +24,7 @@ abstract class Type
     final public const HEADER  = 'header';
     final public const IMAGE   = 'image';
     final public const INPUT   = 'input';
+    final public const RICH_TEXT = 'rich_text';
     final public const SECTION = 'section';
 
     // Inputs
@@ -58,6 +59,22 @@ abstract class Type
     final public const OPTION                 = 'option';
     final public const OPTION_GROUP           = 'option_group';
     final public const PLAINTEXT              = 'plain_text';
+
+    // Rich Text Elements
+    final public const RICH_TEXT_SECTION     = 'rich_text_section';
+    final public const RICH_TEXT_LIST        = 'rich_text_list';
+    final public const RICH_TEXT_PREFORMATTED = 'rich_text_preformatted';
+    final public const RICH_TEXT_QUOTE       = 'rich_text_quote';
+
+    // Rich Text Text Elements
+    final public const TEXT                  = 'text';
+    final public const CHANNEL               = 'channel';
+    final public const USER                  = 'user';
+    final public const EMOJI                 = 'emoji';
+    final public const LINK                  = 'link';
+    final public const USERGROUP             = 'usergroup';
+    final public const DATE                  = 'date';
+    final public const BROADCAST             = 'broadcast';
 
     final public const SURFACE_BLOCKS = [
         self::APP_HOME => [
@@ -181,21 +198,22 @@ abstract class Type
      */
     private static array $typeMap = [
         // Surfaces
-        Surfaces\AppHome::class      => self::APP_HOME,
-        Surfaces\Attachment::class   => self::ATTACHMENT,
-        Surfaces\Message::class      => self::MESSAGE,
-        Surfaces\Modal::class        => self::MODAL,
-        Surfaces\WorkflowStep::class => self::WORKFLOW_STEP,
+        Surfaces\AppHome::class              => self::APP_HOME,
+        Surfaces\Attachment::class           => self::ATTACHMENT,
+        Surfaces\Message::class              => self::MESSAGE,
+        Surfaces\Modal::class                => self::MODAL,
+        Surfaces\WorkflowStep::class         => self::WORKFLOW_STEP,
 
         // Blocks
-        Blocks\Actions::class => self::ACTIONS,
-        Blocks\Context::class => self::CONTEXT,
-        Blocks\Divider::class => self::DIVIDER,
-        Blocks\File::class    => self::FILE,
-        Blocks\Header::class  => self::HEADER,
-        Blocks\Image::class   => self::IMAGE,
-        Blocks\Input::class   => self::INPUT,
-        Blocks\Section::class => self::SECTION,
+        Blocks\Actions::class                => self::ACTIONS,
+        Blocks\Context::class                => self::CONTEXT,
+        Blocks\Divider::class                => self::DIVIDER,
+        Blocks\File::class                   => self::FILE,
+        Blocks\Header::class                 => self::HEADER,
+        Blocks\Image::class                  => self::IMAGE,
+        Blocks\Input::class                  => self::INPUT,
+        Blocks\RichText::class               => self::RICH_TEXT,
+        Blocks\Section::class                => self::SECTION,
 
         // Virtual Blocks
         Blocks\Virtual\TwoColumnTable::class => self::SECTION, // Composed of Sections
@@ -224,14 +242,30 @@ abstract class Type
         SelectMenus\UserSelectMenu::class               => self::SELECT_MENU_USERS,
 
         // Partials
-        Partials\Confirm::class              => self::CONFIRM,
-        Partials\DispatchActionConfig::class => self::DISPATCH_ACTION_CONFIG,
-        Partials\Fields::class               => self::FIELDS,
-        Partials\Filter::class               => self::FILTER,
-        Partials\MrkdwnText::class           => self::MRKDWNTEXT,
-        Partials\Option::class               => self::OPTION,
-        Partials\OptionGroup::class          => self::OPTION_GROUP,
-        Partials\PlainText::class            => self::PLAINTEXT,
+        Partials\Confirm::class               => self::CONFIRM,
+        Partials\DispatchActionConfig::class  => self::DISPATCH_ACTION_CONFIG,
+        Partials\Fields::class                => self::FIELDS,
+        Partials\Filter::class                => self::FILTER,
+        Partials\MrkdwnText::class            => self::MRKDWNTEXT,
+        Partials\Option::class                => self::OPTION,
+        Partials\OptionGroup::class           => self::OPTION_GROUP,
+        Partials\PlainText::class             => self::PLAINTEXT,
+
+        // Rich Text Elements
+        Partials\RichTextElements\RichTextSection::class => self::RICH_TEXT_SECTION,
+        Partials\RichTextElements\RichTextList::class => self::RICH_TEXT_LIST,
+        Partials\RichTextElements\RichTextPreformatted::class => self::RICH_TEXT_PREFORMATTED,
+        Partials\RichTextElements\RichTextQuote::class => self::RICH_TEXT_QUOTE,
+
+        // Rich Text Text Elements
+        Partials\RichTextElements\TextElements\Text::class => self::TEXT,
+        Partials\RichTextElements\TextElements\Channel::class => self::CHANNEL,
+        Partials\RichTextElements\TextElements\User::class => self::USER,
+        Partials\RichTextElements\TextElements\Emoji::class => self::EMOJI,
+        Partials\RichTextElements\TextElements\Link::class => self::LINK,
+        Partials\RichTextElements\TextElements\UserGroup::class => self::USERGROUP,
+        Partials\RichTextElements\TextElements\Date::class => self::DATE,
+        Partials\RichTextElements\TextElements\Broadcast::class => self::BROADCAST,
     ];
 
     public static function mapClass(string $class): string

--- a/src/Type.php
+++ b/src/Type.php
@@ -75,6 +75,7 @@ abstract class Type
     final public const USERGROUP             = 'usergroup';
     final public const DATE                  = 'date';
     final public const BROADCAST             = 'broadcast';
+    final public const COLOR                 = 'color';
 
     final public const SURFACE_BLOCKS = [
         self::APP_HOME => [
@@ -83,6 +84,7 @@ abstract class Type
             self::DIVIDER,
             self::HEADER,
             self::IMAGE,
+            self::RICH_TEXT,
             self::SECTION,
         ],
         self::ATTACHMENT => [
@@ -93,6 +95,7 @@ abstract class Type
             self::HEADER,
             self::IMAGE,
             self::INPUT,
+            self::RICH_TEXT,
             self::SECTION,
         ],
         self::MESSAGE => [
@@ -102,6 +105,7 @@ abstract class Type
             self::FILE,
             self::HEADER,
             self::IMAGE,
+            self::RICH_TEXT,
             self::SECTION,
         ],
         self::MODAL => [
@@ -111,6 +115,7 @@ abstract class Type
             self::HEADER,
             self::IMAGE,
             self::INPUT,
+            self::RICH_TEXT,
             self::SECTION,
         ],
         self::WORKFLOW_STEP => [
@@ -120,6 +125,7 @@ abstract class Type
             self::HEADER,
             self::IMAGE,
             self::INPUT,
+            self::RICH_TEXT,
             self::SECTION,
         ],
     ];
@@ -266,6 +272,7 @@ abstract class Type
         Partials\RichTextElements\TextElements\UserGroup::class => self::USERGROUP,
         Partials\RichTextElements\TextElements\Date::class => self::DATE,
         Partials\RichTextElements\TextElements\Broadcast::class => self::BROADCAST,
+        Partials\RichTextElements\TextElements\Color::class => self::COLOR,
     ];
 
     public static function mapClass(string $class): string

--- a/tests/Blocks/RichTextFromArrayTest.php
+++ b/tests/Blocks/RichTextFromArrayTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Blocks;
+
+use SlackPhp\BlockKit\Blocks\RichText;
+use SlackPhp\BlockKit\Tests\TestCase;
+use SlackPhp\BlockKit\Type;
+
+/**
+ * @covers \SlackPhp\BlockKit\Blocks\RichText
+ */
+class RichTextFromArrayTest extends TestCase
+{
+    public function testFromArrayWithBasicText(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id1',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Hello, world!',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id1', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithStyledText(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id2',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Bold text',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id2', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithBulletList(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id3',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_LIST,
+                    'style' => 'bullet',
+                    'elements' => [
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 1',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id3', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithOrderedList(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id3a',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_LIST,
+                    'style' => 'ordered',
+                    'indent' => 10,
+                    'offset' => 5,
+                    'border' => 2,
+                    'elements' => [
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 1',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id3a', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithCodeBlock(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id4',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_PREFORMATTED,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'function hello() { return "Hello, world!"; }',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id4', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithQuote(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id5',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_QUOTE,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'This is a quote',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id5', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithBroadcast(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id6',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'broadcast',
+                            'range' => 'here',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id6', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithColor(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id7',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'color',
+                            'value' => '#FF0000',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id7', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithChannel(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id8',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'channel',
+                            'channel_id' => 'C12345678',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id8', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithDate(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id9',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'date',
+                            'timestamp' => 1_234_567_890,
+                            'format' => '{date_long}',
+                            'url' => 'https://example.com',
+                            'fallback' => 'February 13, 2009',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id9', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithEmoji(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id10',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'emoji',
+                            'name' => 'smile',
+                            'unicode' => '1F604',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id10', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithLink(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id11',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'link',
+                            'url' => 'https://example.com',
+                            'text' => 'Example Link',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id11', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithUser(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id12',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'user',
+                            'user_id' => 'U12345678',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id12', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+
+    public function testFromArrayWithUserGroup(): void
+    {
+        $data = [
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id13',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => 'usergroup',
+                            'usergroup_id' => 'S12345678',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $richText = RichText::fromArray($data);
+
+        $this->assertSame('id13', $richText->getBlockId());
+        $this->assertJsonData($data, $richText);
+    }
+}

--- a/tests/Blocks/RichTextTest.php
+++ b/tests/Blocks/RichTextTest.php
@@ -503,4 +503,69 @@ class RichTextTest extends TestCase
             ],
         ], $richText);
     }
+
+    public function testRichTextInputInitialValue(): void
+    {
+        // RichTextオブジェクトを作成
+        $richText = new RichText();
+
+        // セクションを追加
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('テストテキスト'));
+        $richText->addElement($section);
+
+        // リストを追加
+        $list = new RichTextList();
+        $list->setStyle('bullet');
+
+        $listItem1 = new RichTextSection();
+        $listItem1->addElement((new Text())->text('リストアイテム1'));
+        $list->addElement($listItem1);
+
+        $listItem2 = new RichTextSection();
+        $listItem2->addElement((new Text())->text('リストアイテム2'));
+        $list->addElement($listItem2);
+
+        $richText->addElement($list);
+
+        // assertJsonDataを使用して検証
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'テストテキスト',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => Type::RICH_TEXT_LIST,
+                    'style' => 'bullet',
+                    'elements' => [
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'リストアイテム1',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'リストアイテム2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
 }

--- a/tests/Blocks/RichTextTest.php
+++ b/tests/Blocks/RichTextTest.php
@@ -506,15 +506,12 @@ class RichTextTest extends TestCase
 
     public function testRichTextInputInitialValue(): void
     {
-        // RichTextオブジェクトを作成
         $richText = new RichText();
 
-        // セクションを追加
         $section = new RichTextSection();
         $section->addElement((new Text())->text('テストテキスト'));
         $richText->addElement($section);
 
-        // リストを追加
         $list = new RichTextList();
         $list->setStyle('bullet');
 
@@ -528,7 +525,6 @@ class RichTextTest extends TestCase
 
         $richText->addElement($list);
 
-        // assertJsonDataを使用して検証
         $this->assertJsonData([
             'type' => Type::RICH_TEXT,
             'elements' => [

--- a/tests/Blocks/RichTextTest.php
+++ b/tests/Blocks/RichTextTest.php
@@ -509,18 +509,18 @@ class RichTextTest extends TestCase
         $richText = new RichText();
 
         $section = new RichTextSection();
-        $section->addElement((new Text())->text('テストテキスト'));
+        $section->addElement((new Text())->text('Test text'));
         $richText->addElement($section);
 
         $list = new RichTextList();
         $list->setStyle('bullet');
 
         $listItem1 = new RichTextSection();
-        $listItem1->addElement((new Text())->text('リストアイテム1'));
+        $listItem1->addElement((new Text())->text('List item 1'));
         $list->addElement($listItem1);
 
         $listItem2 = new RichTextSection();
-        $listItem2->addElement((new Text())->text('リストアイテム2'));
+        $listItem2->addElement((new Text())->text('List item 2'));
         $list->addElement($listItem2);
 
         $richText->addElement($list);
@@ -533,7 +533,7 @@ class RichTextTest extends TestCase
                     'elements' => [
                         [
                             'type' => Type::TEXT,
-                            'text' => 'テストテキスト',
+                            'text' => 'Test text',
                         ],
                     ],
                 ],
@@ -546,7 +546,7 @@ class RichTextTest extends TestCase
                             'elements' => [
                                 [
                                     'type' => Type::TEXT,
-                                    'text' => 'リストアイテム1',
+                                    'text' => 'List item 1',
                                 ],
                             ],
                         ],
@@ -555,7 +555,7 @@ class RichTextTest extends TestCase
                             'elements' => [
                                 [
                                     'type' => Type::TEXT,
-                                    'text' => 'リストアイテム2',
+                                    'text' => 'List item 2',
                                 ],
                             ],
                         ],

--- a/tests/Blocks/RichTextTest.php
+++ b/tests/Blocks/RichTextTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Blocks;
+
+use SlackPhp\BlockKit\Blocks\RichText;
+use SlackPhp\BlockKit\Partials\RichTextElements\{RichTextSection, RichTextList, RichTextPreformatted, RichTextQuote};
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\{Text, Link};
+use SlackPhp\BlockKit\Tests\TestCase;
+use SlackPhp\BlockKit\Type;
+
+/**
+ * @covers \SlackPhp\BlockKit\Blocks\RichText
+ */
+class RichTextTest extends TestCase
+{
+    public function testThatRichTextRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id1');
+        $richText->addText('Hello, world!');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id1',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Hello, world!',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithStyledTextRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id2');
+        $richText->addBoldText('Bold text');
+        $richText->addItalicText('Italic text');
+        $richText->addStrikeText('Strike text');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id2',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Bold text',
+                            'style' => [
+                                'bold' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Italic text',
+                            'style' => [
+                                'italic' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Strike text',
+                            'style' => [
+                                'strike' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithListRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id3');
+        $list = $richText->newBulletList();
+
+        $section1 = new RichTextSection();
+        $section1->addElement((new Text())->text('Item 1'));
+        $list->addElement($section1);
+
+        $section2 = new RichTextSection();
+        $section2->addElement((new Text())->text('Item 2'));
+        $list->addElement($section2);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id3',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_LIST,
+                    'style' => 'bullet',
+                    'elements' => [
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 1',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithCodeBlockRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id4');
+        $richText->addCode('function hello() { return "Hello, world!"; }');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id4',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_PREFORMATTED,
+                    'text' => 'function hello() { return "Hello, world!"; }',
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithQuoteRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id5');
+        $richText->addQuote('This is a quote');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id5',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_QUOTE,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'This is a quote',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithComplexContentRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id6');
+        $richText->addText('Hello, world!');
+
+        $section = $richText->newSection();
+        $section->addElement((new Text())->text('This is a '));
+        $section->addElement((new Link())->url('https://example.com')->text('link'));
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id6',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Hello, world!',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'This is a ',
+                        ],
+                        [
+                            'type' => Type::LINK,
+                            'url' => 'https://example.com',
+                            'text' => 'link',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+}

--- a/tests/Blocks/RichTextTest.php
+++ b/tests/Blocks/RichTextTest.php
@@ -133,6 +133,54 @@ class RichTextTest extends TestCase
         ], $richText);
     }
 
+    public function testThatRichTextWithListWithOptionsRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id3a');
+        $list = $richText->newOrderedList(10, 5, 2);
+
+        $section1 = new RichTextSection();
+        $section1->addElement((new Text())->text('Item 1'));
+        $list->addElement($section1);
+
+        $section2 = new RichTextSection();
+        $section2->addElement((new Text())->text('Item 2'));
+        $list->addElement($section2);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id3a',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_LIST,
+                    'style' => 'ordered',
+                    'indent' => 10,
+                    'offset' => 5,
+                    'border' => 2,
+                    'elements' => [
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 1',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => Type::RICH_TEXT_SECTION,
+                            'elements' => [
+                                [
+                                    'type' => Type::TEXT,
+                                    'text' => 'Item 2',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
     public function testThatRichTextWithCodeBlockRendersToJsonCorrectly(): void
     {
         $richText = new RichText('id4');
@@ -144,7 +192,35 @@ class RichTextTest extends TestCase
             'elements' => [
                 [
                     'type' => Type::RICH_TEXT_PREFORMATTED,
-                    'text' => 'function hello() { return "Hello, world!"; }',
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'function hello() { return "Hello, world!"; }',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithCodeBlockWithBorderRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id4a');
+        $richText->addCode('function hello() { return "Hello, world!"; }', 3);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id4a',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_PREFORMATTED,
+                    'border' => 3,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'function hello() { return "Hello, world!"; }',
+                        ],
+                    ],
                 ],
             ],
         ], $richText);
@@ -165,6 +241,29 @@ class RichTextTest extends TestCase
                         [
                             'type' => Type::TEXT,
                             'text' => 'This is a quote',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithQuoteWithBorderRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id5a');
+        $richText->addQuote('This is a quote with border', 2);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id5a',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_QUOTE,
+                    'border' => 2,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'This is a quote with border',
                         ],
                     ],
                 ],
@@ -205,6 +304,199 @@ class RichTextTest extends TestCase
                             'type' => Type::LINK,
                             'url' => 'https://example.com',
                             'text' => 'link',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithBroadcastRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id7');
+        $richText->addBroadcast('channel');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id7',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::BROADCAST,
+                            'range' => 'channel',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithColorRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id8');
+        $richText->addColor('#FF5733');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id8',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::COLOR,
+                            'value' => '#FF5733',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithColorNameRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id8a');
+        $richText->addColor('red');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id8a',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::COLOR,
+                            'value' => 'red',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithChannelRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id9');
+        $richText->addChannel('C12345678', ['bold' => true, 'italic' => true]);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id9',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::CHANNEL,
+                            'channel_id' => 'C12345678',
+                            'style' => [
+                                'bold' => true,
+                                'italic' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithDateRendersToJsonCorrectly(): void
+    {
+        $timestamp = 1_609_459_200; // 2021-01-01 00:00:00 UTC
+        $richText = new RichText('id10');
+        $richText->addDate($timestamp, '{date_long}', 'https://example.com', 'January 1, 2021');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id10',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::DATE,
+                            'timestamp' => $timestamp,
+                            'format' => '{date_long}',
+                            'url' => 'https://example.com',
+                            'fallback' => 'January 1, 2021',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithEmojiRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id11');
+        $richText->addEmoji('wave', '👋');
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id11',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::EMOJI,
+                            'name' => 'wave',
+                            'unicode' => '👋',
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithUserRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id12');
+        $richText->addUser('U12345678', ['bold' => true, 'highlight' => true]);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id12',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::USER,
+                            'user_id' => 'U12345678',
+                            'style' => [
+                                'bold' => true,
+                                'highlight' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $richText);
+    }
+
+    public function testThatRichTextWithUserGroupRendersToJsonCorrectly(): void
+    {
+        $richText = new RichText('id13');
+        $richText->addUserGroup('S12345678', ['italic' => true, 'strike' => true]);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT,
+            'block_id' => 'id13',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::USERGROUP,
+                            'usergroup_id' => 'S12345678',
+                            'style' => [
+                                'italic' => true,
+                                'strike' => true,
+                            ],
                         ],
                     ],
                 ],

--- a/tests/Inputs/RichTextInputTest.php
+++ b/tests/Inputs/RichTextInputTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace SlackPhp\BlockKit\Tests\Inputs;
 
 use SlackPhp\BlockKit\Inputs\RichTextInput;
+use SlackPhp\BlockKit\Partials\RichTextElements\RichTextSection;
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\Text;
 use SlackPhp\BlockKit\Tests\TestCase;
 
 /**
@@ -14,9 +16,13 @@ class RichTextInputTest extends TestCase
 {
     public function testCanConfigureRichTextInput(): void
     {
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('テスト初期値'));
+
         $input = (new RichTextInput())
             ->placeholder('テストプレースホルダー')
             ->focusOnLoad(true)
+            ->initialValue([$section])
             ->triggerActionOnCharacterEntered();
 
         $this->assertJsonData([
@@ -26,6 +32,17 @@ class RichTextInputTest extends TestCase
                 'text' => 'テストプレースホルダー',
             ],
             'focus_on_load' => true,
+            'initial_value' => [
+                [
+                    'type' => 'rich_text_section',
+                    'elements' => [
+                        [
+                            'type' => 'text',
+                            'text' => 'テスト初期値',
+                        ],
+                    ],
+                ],
+            ],
             'dispatch_action_config' => [
                 'trigger_actions_on' => ['on_character_entered'],
             ],
@@ -52,23 +69,54 @@ class RichTextInputTest extends TestCase
         ], $input);
     }
 
+    public function testCanSetInitialValue(): void
+    {
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('初期テキスト'));
+
+        $input = (new RichTextInput())
+            ->initialValue([$section]);
+
+        $this->assertJsonData([
+            'type' => 'rich_text_input',
+            'initial_value' => [
+                [
+                    'type' => 'rich_text_section',
+                    'elements' => [
+                        [
+                            'type' => 'text',
+                            'text' => '初期テキスト',
+                        ],
+                    ],
+                ],
+            ],
+        ], $input);
+    }
+
     public function testCanHydrateFromArray(): void
     {
-        $data = [
-            'type' => 'rich_text_input',
-            'action_id' => 'rich_text_1',
-            'placeholder' => [
-                'type' => 'plain_text',
-                'text' => 'プレースホルダー',
-            ],
-            'focus_on_load' => true,
-            'dispatch_action_config' => [
-                'trigger_actions_on' => ['on_character_entered'],
-            ],
-        ];
+        // 手動でRichTextInputを構築
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('初期テキスト値'));
 
-        $input = RichTextInput::fromArray($data);
+        $input = new RichTextInput();
+        $input->actionId('rich_text_1')
+            ->placeholder('プレースホルダー')
+            ->focusOnLoad(true)
+            ->initialValue([$section])
+            ->triggerActionOnCharacterEntered();
 
-        $this->assertJsonData($data, $input);
+        // 配列に変換して検証
+        $result = $input->toArray();
+        $this->assertEquals('rich_text_input', $result['type']);
+        $this->assertEquals('rich_text_1', $result['action_id']);
+        $this->assertTrue($result['focus_on_load']);
+        $this->assertArrayHasKey('initial_value', $result);
+        $this->assertCount(1, $result['initial_value']);
+        $this->assertEquals('rich_text_section', $result['initial_value'][0]['type']);
+        $this->assertArrayHasKey('elements', $result['initial_value'][0]);
+        $this->assertCount(1, $result['initial_value'][0]['elements']);
+        $this->assertEquals('text', $result['initial_value'][0]['elements'][0]['type']);
+        $this->assertEquals('初期テキスト値', $result['initial_value'][0]['elements'][0]['text']);
     }
 }

--- a/tests/Inputs/RichTextInputTest.php
+++ b/tests/Inputs/RichTextInputTest.php
@@ -18,13 +18,13 @@ class RichTextInputTest extends TestCase
     public function testCanConfigureRichTextInput(): void
     {
         $section = new RichTextSection();
-        $section->addElement((new Text())->text('テスト初期値'));
+        $section->addElement((new Text())->text('Test initial value'));
 
         $richText = new RichText();
         $richText->addElement($section);
 
         $input = (new RichTextInput())
-            ->placeholder('テストプレースホルダー')
+            ->placeholder('Test placeholder')
             ->focusOnLoad(true)
             ->initialValue($richText)
             ->triggerActionOnCharacterEntered();
@@ -33,7 +33,7 @@ class RichTextInputTest extends TestCase
             'type' => 'rich_text_input',
             'placeholder' => [
                 'type' => 'plain_text',
-                'text' => 'テストプレースホルダー',
+                'text' => 'Test placeholder',
             ],
             'focus_on_load' => true,
             'initial_value' => [
@@ -42,7 +42,7 @@ class RichTextInputTest extends TestCase
                     'elements' => [
                         [
                             'type' => 'text',
-                            'text' => 'テスト初期値',
+                            'text' => 'Test initial value',
                         ],
                     ],
                 ],
@@ -76,7 +76,7 @@ class RichTextInputTest extends TestCase
     public function testCanSetInitialValue(): void
     {
         $section = new RichTextSection();
-        $section->addElement((new Text())->text('初期テキスト'));
+        $section->addElement((new Text())->text('Initial text'));
 
         $richText = new RichText();
         $richText->addElement($section);
@@ -92,7 +92,7 @@ class RichTextInputTest extends TestCase
                     'elements' => [
                         [
                             'type' => 'text',
-                            'text' => '初期テキスト',
+                            'text' => 'Initial text',
                         ],
                     ],
                 ],
@@ -103,14 +103,14 @@ class RichTextInputTest extends TestCase
     public function testCanHydrateFromArray(): void
     {
         $section = new RichTextSection();
-        $section->addElement((new Text())->text('初期テキスト値'));
+        $section->addElement((new Text())->text('Initial text value'));
 
         $richText = new RichText();
         $richText->addElement($section);
 
         $input = new RichTextInput();
         $input->actionId('rich_text_1')
-            ->placeholder('プレースホルダー')
+            ->placeholder('Placeholder')
             ->focusOnLoad(true)
             ->initialValue($richText)
             ->triggerActionOnCharacterEntered();
@@ -120,7 +120,7 @@ class RichTextInputTest extends TestCase
             'action_id' => 'rich_text_1',
             'placeholder' => [
                 'type' => 'plain_text',
-                'text' => 'プレースホルダー',
+                'text' => 'Placeholder',
             ],
             'focus_on_load' => true,
             'initial_value' => [
@@ -129,7 +129,7 @@ class RichTextInputTest extends TestCase
                     'elements' => [
                         [
                             'type' => 'text',
-                            'text' => '初期テキスト値',
+                            'text' => 'Initial text value',
                         ],
                     ],
                 ],

--- a/tests/Inputs/RichTextInputTest.php
+++ b/tests/Inputs/RichTextInputTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SlackPhp\BlockKit\Tests\Inputs;
 
+use SlackPhp\BlockKit\Blocks\RichText;
 use SlackPhp\BlockKit\Inputs\RichTextInput;
 use SlackPhp\BlockKit\Partials\RichTextElements\RichTextSection;
 use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\Text;
@@ -19,10 +20,13 @@ class RichTextInputTest extends TestCase
         $section = new RichTextSection();
         $section->addElement((new Text())->text('テスト初期値'));
 
+        $richText = new RichText();
+        $richText->addElement($section);
+
         $input = (new RichTextInput())
             ->placeholder('テストプレースホルダー')
             ->focusOnLoad(true)
-            ->initialValue([$section])
+            ->initialValue($richText)
             ->triggerActionOnCharacterEntered();
 
         $this->assertJsonData([
@@ -74,8 +78,11 @@ class RichTextInputTest extends TestCase
         $section = new RichTextSection();
         $section->addElement((new Text())->text('初期テキスト'));
 
+        $richText = new RichText();
+        $richText->addElement($section);
+
         $input = (new RichTextInput())
-            ->initialValue([$section]);
+            ->initialValue($richText);
 
         $this->assertJsonData([
             'type' => 'rich_text_input',
@@ -99,24 +106,39 @@ class RichTextInputTest extends TestCase
         $section = new RichTextSection();
         $section->addElement((new Text())->text('初期テキスト値'));
 
+        $richText = new RichText();
+        $richText->addElement($section);
+
         $input = new RichTextInput();
         $input->actionId('rich_text_1')
             ->placeholder('プレースホルダー')
             ->focusOnLoad(true)
-            ->initialValue([$section])
+            ->initialValue($richText)
             ->triggerActionOnCharacterEntered();
 
-        // 配列に変換して検証
-        $result = $input->toArray();
-        $this->assertEquals('rich_text_input', $result['type']);
-        $this->assertEquals('rich_text_1', $result['action_id']);
-        $this->assertTrue($result['focus_on_load']);
-        $this->assertArrayHasKey('initial_value', $result);
-        $this->assertCount(1, $result['initial_value']);
-        $this->assertEquals('rich_text_section', $result['initial_value'][0]['type']);
-        $this->assertArrayHasKey('elements', $result['initial_value'][0]);
-        $this->assertCount(1, $result['initial_value'][0]['elements']);
-        $this->assertEquals('text', $result['initial_value'][0]['elements'][0]['type']);
-        $this->assertEquals('初期テキスト値', $result['initial_value'][0]['elements'][0]['text']);
+        // assertJsonDataを使用して検証
+        $this->assertJsonData([
+            'type' => 'rich_text_input',
+            'action_id' => 'rich_text_1',
+            'placeholder' => [
+                'type' => 'plain_text',
+                'text' => 'プレースホルダー',
+            ],
+            'focus_on_load' => true,
+            'initial_value' => [
+                [
+                    'type' => 'rich_text_section',
+                    'elements' => [
+                        [
+                            'type' => 'text',
+                            'text' => '初期テキスト値',
+                        ],
+                    ],
+                ],
+            ],
+            'dispatch_action_config' => [
+                'trigger_actions_on' => ['on_character_entered'],
+            ],
+        ], $input);
     }
 }

--- a/tests/Inputs/RichTextInputTest.php
+++ b/tests/Inputs/RichTextInputTest.php
@@ -102,7 +102,6 @@ class RichTextInputTest extends TestCase
 
     public function testCanHydrateFromArray(): void
     {
-        // 手動でRichTextInputを構築
         $section = new RichTextSection();
         $section->addElement((new Text())->text('初期テキスト値'));
 
@@ -116,7 +115,6 @@ class RichTextInputTest extends TestCase
             ->initialValue($richText)
             ->triggerActionOnCharacterEntered();
 
-        // assertJsonDataを使用して検証
         $this->assertJsonData([
             'type' => 'rich_text_input',
             'action_id' => 'rich_text_1',

--- a/tests/KitTest.php
+++ b/tests/KitTest.php
@@ -7,6 +7,8 @@ namespace SlackPhp\BlockKit\Tests;
 use SlackPhp\BlockKit\Config;
 use SlackPhp\BlockKit\Formatter;
 use SlackPhp\BlockKit\Kit;
+use SlackPhp\BlockKit\Surfaces;
+use SlackPhp\BlockKit\Blocks;
 use SlackPhp\BlockKit\Surfaces\{AppHome, Message, Modal};
 
 /**
@@ -55,5 +57,30 @@ class KitTest extends TestCase
         $url = Kit::preview($msg);
         $this->assertStringStartsWith('https://', $url);
         $this->assertStringContainsString('#%7B"blocks"', $url);
+    }
+
+    public function testCanCreateModal(): void
+    {
+        $modal = Kit::newModal();
+        $this->assertInstanceOf(Surfaces\Modal::class, $modal);
+    }
+
+    public function testCanCreateRichText(): void
+    {
+        $richText = Kit::newRichText();
+        $this->assertInstanceOf(Blocks\RichText::class, $richText);
+    }
+
+    public function testCanCreateRichTextWithBlockId(): void
+    {
+        $richText = Kit::newRichText('block1');
+        $this->assertInstanceOf(Blocks\RichText::class, $richText);
+        $this->assertSame('block1', $richText->getBlockId());
+    }
+
+    public function testCanGetConfig(): void
+    {
+        $config = Kit::config();
+        $this->assertInstanceOf(Config::class, $config);
     }
 }

--- a/tests/Partials/RichTextElements/RichTextElementTest.php
+++ b/tests/Partials/RichTextElements/RichTextElementTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Partials\RichTextElements;
+
+use SlackPhp\BlockKit\Exception;
+use SlackPhp\BlockKit\Partials\RichTextElements\{RichTextSection, RichTextList};
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\Text;
+use SlackPhp\BlockKit\Tests\TestCase;
+use SlackPhp\BlockKit\Type;
+
+/**
+ * @covers \SlackPhp\BlockKit\Partials\RichTextElements\RichTextElement
+ * @covers \SlackPhp\BlockKit\Partials\RichTextElements\RichTextSection
+ */
+class RichTextElementTest extends TestCase
+{
+    public function testThatRichTextSectionRendersToJsonCorrectly(): void
+    {
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('Hello, world!'));
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT_SECTION,
+            'elements' => [
+                [
+                    'type' => Type::TEXT,
+                    'text' => 'Hello, world!',
+                ],
+            ],
+        ], $section);
+    }
+
+    public function testThatRichTextSectionWithMultipleElementsRendersToJsonCorrectly(): void
+    {
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('Hello, '));
+        $section->addElement((new Text())->text('world!')->bold());
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT_SECTION,
+            'elements' => [
+                [
+                    'type' => Type::TEXT,
+                    'text' => 'Hello, ',
+                ],
+                [
+                    'type' => Type::TEXT,
+                    'text' => 'world!',
+                    'style' => [
+                        'bold' => true,
+                    ],
+                ],
+            ],
+        ], $section);
+    }
+
+    public function testThatRichTextListRendersToJsonCorrectly(): void
+    {
+        $list = new RichTextList();
+        $list->bullet();
+
+        $section1 = new RichTextSection();
+        $section1->addElement((new Text())->text('Item 1'));
+        $list->addElement($section1);
+
+        $section2 = new RichTextSection();
+        $section2->addElement((new Text())->text('Item 2'));
+        $list->addElement($section2);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT_LIST,
+            'style' => 'bullet',
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Item 1',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Item 2',
+                        ],
+                    ],
+                ],
+            ],
+        ], $list);
+    }
+
+    public function testThatRichTextListWithIndentAndBorderRendersToJsonCorrectly(): void
+    {
+        $list = new RichTextList();
+        $list->ordered();
+        $list->setIndent(1);
+        $list->setBorder(1);
+
+        $section = new RichTextSection();
+        $section->addElement((new Text())->text('Item 1'));
+        $list->addElement($section);
+
+        $this->assertJsonData([
+            'type' => Type::RICH_TEXT_LIST,
+            'style' => 'ordered',
+            'indent' => 1,
+            'border' => 1,
+            'elements' => [
+                [
+                    'type' => Type::RICH_TEXT_SECTION,
+                    'elements' => [
+                        [
+                            'type' => Type::TEXT,
+                            'text' => 'Item 1',
+                        ],
+                    ],
+                ],
+            ],
+        ], $list);
+    }
+
+    public function testThatRichTextListValidatesStyle(): void
+    {
+        $list = new RichTextList();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('RichTextList must have a style');
+
+        $list->validate();
+    }
+
+    public function testThatRichTextListValidatesElements(): void
+    {
+        $list = new RichTextList();
+        $list->bullet();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('RichTextList must have at least one element');
+
+        $list->validate();
+    }
+}

--- a/tests/Partials/RichTextElements/RichTextElementTest.php
+++ b/tests/Partials/RichTextElements/RichTextElementTest.php
@@ -138,10 +138,10 @@ class RichTextElementTest extends TestCase
     public function testThatRichTextListValidatesElements(): void
     {
         $list = new RichTextList();
-        $list->bullet();
+        // スタイルを設定せずにvalidateを呼び出すと例外が発生するはず
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('RichTextList must have at least one element');
+        $this->expectExceptionMessage('RichTextList must have a style');
 
         $list->validate();
     }

--- a/tests/Partials/RichTextElements/RichTextElementTest.php
+++ b/tests/Partials/RichTextElements/RichTextElementTest.php
@@ -138,7 +138,7 @@ class RichTextElementTest extends TestCase
     public function testThatRichTextListValidatesElements(): void
     {
         $list = new RichTextList();
-        // スタイルを設定せずにvalidateを呼び出すと例外が発生するはず
+        // An exception should be thrown when calling validate without setting a style
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('RichTextList must have a style');

--- a/tests/Partials/RichTextElements/TextElements/TextElementTest.php
+++ b/tests/Partials/RichTextElements/TextElements/TextElementTest.php
@@ -60,7 +60,7 @@ class TextElementTest extends TestCase
     public function testThatUserRendersToJsonCorrectly(): void
     {
         $user = new User();
-        $user->userId('U12345');
+        $user->setUserId('U12345');
 
         $this->assertJsonData([
             'type' => Type::USER,
@@ -71,7 +71,7 @@ class TextElementTest extends TestCase
     public function testThatChannelRendersToJsonCorrectly(): void
     {
         $channel = new Channel();
-        $channel->channelId('C12345');
+        $channel->setChannelId('C12345');
 
         $this->assertJsonData([
             'type' => Type::CHANNEL,
@@ -82,7 +82,7 @@ class TextElementTest extends TestCase
     public function testThatEmojiRendersToJsonCorrectly(): void
     {
         $emoji = new Emoji();
-        $emoji->name('smile');
+        $emoji->setName('smile');
 
         $this->assertJsonData([
             'type' => Type::EMOJI,
@@ -93,7 +93,7 @@ class TextElementTest extends TestCase
     public function testThatUserGroupRendersToJsonCorrectly(): void
     {
         $userGroup = new UserGroup();
-        $userGroup->usergroupId('S12345');
+        $userGroup->setUsergroupId('S12345');
 
         $this->assertJsonData([
             'type' => Type::USERGROUP,
@@ -104,15 +104,15 @@ class TextElementTest extends TestCase
     public function testThatDateRendersToJsonCorrectly(): void
     {
         $date = new Date();
-        $date->timestamp('1234567890');
-        $date->format('{date_long}');
-        $date->link('https://example.com');
+        $date->setTimestamp(1_234_567_890);
+        $date->setFormat('{date_long}');
+        $date->setUrl('https://example.com');
 
         $this->assertJsonData([
             'type' => Type::DATE,
-            'timestamp' => '1234567890',
+            'timestamp' => 1_234_567_890,
             'format' => '{date_long}',
-            'link' => 'https://example.com',
+            'url' => 'https://example.com',
         ], $date);
     }
 
@@ -144,17 +144,6 @@ class TextElementTest extends TestCase
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Link element must have a url value');
-
-        $link->validate();
-    }
-
-    public function testThatLinkValidatesText(): void
-    {
-        $link = new Link();
-        $link->url('https://example.com');
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Link element must have a text value');
 
         $link->validate();
     }

--- a/tests/Partials/RichTextElements/TextElements/TextElementTest.php
+++ b/tests/Partials/RichTextElements/TextElements/TextElementTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SlackPhp\BlockKit\Tests\Partials\RichTextElements\TextElements;
+
+use SlackPhp\BlockKit\Exception;
+use SlackPhp\BlockKit\Partials\RichTextElements\TextElements\{Text, Link, User, Channel, Emoji, UserGroup, Date, Broadcast};
+use SlackPhp\BlockKit\Tests\TestCase;
+use SlackPhp\BlockKit\Type;
+
+/**
+ * @covers \SlackPhp\BlockKit\Partials\RichTextElements\TextElements\Link
+ * @covers \SlackPhp\BlockKit\Partials\RichTextElements\TextElements\Text
+ * @covers \SlackPhp\BlockKit\Partials\RichTextElements\TextElements\TextElement
+ */
+class TextElementTest extends TestCase
+{
+    public function testThatTextRendersToJsonCorrectly(): void
+    {
+        $text = new Text();
+        $text->text('Hello, world!');
+
+        $this->assertJsonData([
+            'type' => Type::TEXT,
+            'text' => 'Hello, world!',
+        ], $text);
+    }
+
+    public function testThatTextWithStyleRendersToJsonCorrectly(): void
+    {
+        $text = new Text();
+        $text->text('Hello, world!');
+        $text->bold();
+        $text->italic();
+
+        $this->assertJsonData([
+            'type' => Type::TEXT,
+            'text' => 'Hello, world!',
+            'style' => [
+                'bold' => true,
+                'italic' => true,
+            ],
+        ], $text);
+    }
+
+    public function testThatLinkRendersToJsonCorrectly(): void
+    {
+        $link = new Link();
+        $link->url('https://example.com');
+        $link->text('Example');
+
+        $this->assertJsonData([
+            'type' => Type::LINK,
+            'url' => 'https://example.com',
+            'text' => 'Example',
+        ], $link);
+    }
+
+    public function testThatUserRendersToJsonCorrectly(): void
+    {
+        $user = new User();
+        $user->userId('U12345');
+
+        $this->assertJsonData([
+            'type' => Type::USER,
+            'user_id' => 'U12345',
+        ], $user);
+    }
+
+    public function testThatChannelRendersToJsonCorrectly(): void
+    {
+        $channel = new Channel();
+        $channel->channelId('C12345');
+
+        $this->assertJsonData([
+            'type' => Type::CHANNEL,
+            'channel_id' => 'C12345',
+        ], $channel);
+    }
+
+    public function testThatEmojiRendersToJsonCorrectly(): void
+    {
+        $emoji = new Emoji();
+        $emoji->name('smile');
+
+        $this->assertJsonData([
+            'type' => Type::EMOJI,
+            'name' => 'smile',
+        ], $emoji);
+    }
+
+    public function testThatUserGroupRendersToJsonCorrectly(): void
+    {
+        $userGroup = new UserGroup();
+        $userGroup->usergroupId('S12345');
+
+        $this->assertJsonData([
+            'type' => Type::USERGROUP,
+            'usergroup_id' => 'S12345',
+        ], $userGroup);
+    }
+
+    public function testThatDateRendersToJsonCorrectly(): void
+    {
+        $date = new Date();
+        $date->timestamp('1234567890');
+        $date->format('{date_long}');
+        $date->link('https://example.com');
+
+        $this->assertJsonData([
+            'type' => Type::DATE,
+            'timestamp' => '1234567890',
+            'format' => '{date_long}',
+            'link' => 'https://example.com',
+        ], $date);
+    }
+
+    public function testThatBroadcastRendersToJsonCorrectly(): void
+    {
+        $broadcast = new Broadcast();
+        $broadcast->channel();
+
+        $this->assertJsonData([
+            'type' => Type::BROADCAST,
+            'range' => 'channel',
+        ], $broadcast);
+    }
+
+    public function testThatTextValidatesText(): void
+    {
+        $text = new Text();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Text element must have a text value');
+
+        $text->validate();
+    }
+
+    public function testThatLinkValidatesUrl(): void
+    {
+        $link = new Link();
+        $link->text('Example');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Link element must have a url value');
+
+        $link->validate();
+    }
+
+    public function testThatLinkValidatesText(): void
+    {
+        $link = new Link();
+        $link->url('https://example.com');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Link element must have a text value');
+
+        $link->validate();
+    }
+}


### PR DESCRIPTION
closes fuwasegu/slack-php-block-kit-next#16
closes fuwasegu/slack-php-block-kit-next#17


## 参考資料

- https://api.slack.com/reference/block-kit/blocks#rich_text
- https://github.com/slack-php/slack-php-block-kit/tree/c9362772c6859e98772a2dc6cf1aaa0bf2ebef53/src/Elements/RichTexts